### PR TITLE
Change process error to printed error upon lint error

### DIFF
--- a/anaconda_linter/run.py
+++ b/anaconda_linter/run.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import sys
 import textwrap
 
 from . import lint, utils

--- a/anaconda_linter/run.py
+++ b/anaconda_linter/run.py
@@ -106,7 +106,7 @@ def main():
     elif overall_result == lint.WARNING:
         print("Warnings were found")
     else:
-        sys.exit("Errors were found")
+        print("Errors were found")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Because: when running on a prefect agent, the flow run will currently terminate if there are lint errors. This is probably because the linter process returns with sys.exit(non-zero), and prefect considers this as a failed run. If the flow run terminates, it can't go on to do other stuff, like update the status of the PR or post lint results.

This changes it to simply print the error string. Also, we need to release a new linter after this in order to get automatic github PR checks working.