### PR TITLE
Fix installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,11 @@ release: dist ## package and upload a release
 	twine upload dist/*
 
 dist: clean ## builds source and wheel package
-	python setup.py sdist
-	python setup.py bdist_wheel
+	python -m build
 	ls -l dist
 
 install: clean ## install the package to the active Python's site-packages
-	python setup.py install
+	pip install .
+
+dev: clean  ## install the package's development version
+	pip install -e .

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ that packages' meta.yaml files adhere to certain Anaconda standards.
 ## Installation
 1. `conda env create -f environment.yaml`
 2. `conda activate anaconda-linter`
-3. `python setup.py install`
+3. `make install`
 
 ## Usage
 

--- a/anaconda_linter/__init__.py
+++ b/anaconda_linter/__init__.py
@@ -1,4 +1,4 @@
-__name__ = "anaconda-linter"
+__name__ = "anaconda_linter"
 __version__ = "0.0.3"
 __author__ = "Anaconda, Inc."
 __email__ = "distribution_team@anaconda.com"

--- a/setup.py
+++ b/setup.py
@@ -14,16 +14,16 @@ def main():
 
     requirements = [
         "conda-build",
-        "jinja2>=3.0.3",
+        "jinja2",
         "jsonschema",
         "license-expression",
         "networkx",
         "pyyaml",
         "requests",
-        "ruamel.yaml>=0.16.1",
+        "ruamel.yaml",
         "tqdm",
     ]
-    test_requirements = ["pytest>=3", "pytest-cov", "pytest-html"]
+    test_requirements = ["pytest", "pytest-cov", "pytest-html"]
 
     run_lint = dict(
         author_email=anaconda_linter.__email__,


### PR DESCRIPTION
This PR fixes the installation of the anaconda-linter package

Changes:

* Update the package name
* Remove version pinnings - especially jinja2 conflicts with conda-build
* Switch to pip install since setup.py is deprecated