### PR TITLE
Add lint unit tests

### DIFF
--- a/anaconda_linter/lint/check_url.py
+++ b/anaconda_linter/lint/check_url.py
@@ -21,6 +21,7 @@ class invalid_url(LintCheck):
             response_data = utils.check_url(url)
             acceptable_redirects = [
                 ("pypi.io", "pypi.org"),
+                ("pypi.org", "files.pythonhosted.org"),
                 ("github.com", "objects.githubusercontent.com"),
                 ("github.com", "codeload.github.com"),
             ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,10 @@ target-version = ['py37', 'py38', 'py39']
 profile = "black"
 line_length = 100
 src_paths = ["anaconda_linter"]
++
+[tool.pytest.ini_options]
+filterwarnings = [
+    # Skip PendingDeprecationWarning from conda-build
+    "ignore:.*`conda\\.exports\\.memoized`.*:PendingDeprecationWarning",
+    "ignore:.*`conda\\._vendor\\.toolz`.*:PendingDeprecationWarning",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ target-version = ['py37', 'py38', 'py39']
 profile = "black"
 line_length = 100
 src_paths = ["anaconda_linter"]
-+
+
 [tool.pytest.ini_options]
 filterwarnings = [
     # Skip PendingDeprecationWarning from conda-build

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -474,6 +474,21 @@ def test_missing_pip_check_url_bad(base_yaml):
     assert len(messages) == 1 and "pip check should be present" in messages[0].title
 
 
+# This test covers part of the is_pypi_source function
+def test_missing_pip_check_url_list_bad(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          - url: https://github.com/joblib/joblib/archive/1.1.1.tar.gz
+          - url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        """
+    )
+    lint_check = "missing_pip_check"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 1 and "pip check should be present" in messages[0].title
+
+
 def test_missing_pip_check_pip_install_good(base_yaml):
     yaml_str = (
         base_yaml

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -170,7 +170,7 @@ def test_missing_tests_good_scripts(base_yaml):
         with tempfile.TemporaryDirectory() as tmpdir:
             recipe_dir = os.path.join(tmpdir, "recipe")
             os.mkdir(recipe_dir)
-            with open(os.path.join(recipe_dir, test_file), "wt") as f:
+            with open(os.path.join(recipe_dir, test_file), "w") as f:
                 f.write("\n")
             messages = check_dir(lint_check, tmpdir, base_yaml)
             assert len(messages) == 0

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -1,4 +1,7 @@
-from conftest import check
+import os
+import tempfile
+
+from conftest import check, check_dir
 
 
 def test_missing_build_number_good(base_yaml):
@@ -156,6 +159,21 @@ def test_missing_tests_good_command(base_yaml):
     lint_check = "missing_tests"
     messages = check(lint_check, yaml_str)
     assert len(messages) == 0
+
+
+def test_missing_tests_good_scripts(base_yaml):
+    lint_check = "missing_tests"
+
+    test_files = ["run_test.py", "run_test.sh", "run_test.pl"]
+
+    for test_file in test_files:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recipe_dir = os.path.join(tmpdir, "recipe")
+            os.mkdir(recipe_dir)
+            with open(os.path.join(recipe_dir, test_file), "wt") as f:
+                f.write("\n")
+            messages = check_dir(lint_check, tmpdir, base_yaml)
+            assert len(messages) == 0
 
 
 def test_missing_tests_bad_missing(base_yaml):

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -27,6 +27,28 @@ def test_invalid_url_bad(base_yaml):
     assert len(messages) == 1
 
 
+def test_invalid_url_about_bad(base_yaml):
+    url_fields = [
+        "home",
+        "doc_url",
+        "doc_source_url",
+        "license_url",
+        "dev_url",
+    ]
+
+    lint_check = "invalid_url"
+    for field in url_fields:
+        yaml_str = (
+            base_yaml
+            + f"""
+        about:
+          {field}: https://sqlit.org/
+            """
+        )
+        messages = check(lint_check, yaml_str)
+        assert len(messages) == 1, f"Check failed for {field}"
+
+
 def test_invalid_url_redirect_good(base_yaml):
     redirect_urls = [
         {

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -56,6 +56,10 @@ def test_invalid_url_redirect_good(base_yaml):
             "redirect": "pypi.io -> pypi.org",
         },
         {
+            "source": "https://pypi.org/packages/source/D/Django/Django-4.1.tar.gz",
+            "redirect": "pypi.org -> files.pythonhosted.org",
+        },
+        {
             "source": "https://github.com/beekeeper-studio/beekeeper-studio/"
             "releases/download/v3.6.2/Beekeeper-Studio-3.6.2-portable.exe",
             "redirect": "github.com -> objects.githubusercontent.com",


### PR DESCRIPTION
Add additional unit tests, increasing coverage for build_help and completeness to 100%.

Also suppresses the PendingDeprecationWarnings pytest throws because of `conda-build`.