### PR TITLE
use crender

### DIFF
--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -439,13 +439,6 @@ class missing_meta_yaml(LintCheck):
     """
 
 
-class conda_render_failure(LintCheck):
-    """The recipe was not understood by conda-build
-
-    Please request help from cconda-lint.
-    """
-
-
 class jinja_render_failure(LintCheck):
     """The recipe could not be rendered by Jinja2
 
@@ -470,7 +463,6 @@ recipe_error_to_lint_check = {
     _recipe.MissingBuild: missing_build,
     _recipe.HasSelector: unknown_selector,
     _recipe.MissingMetaYaml: missing_meta_yaml,
-    _recipe.CondaRenderFailure: conda_render_failure,
     _recipe.RenderFailure: jinja_render_failure,
 }
 

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -2,8 +2,6 @@ avoid_noarch
 
 compilers_must_be_in_build
 
-conda_render_failure
-
 cython_must_be_in_host
 
 cython_needs_compiler

--- a/environment.yaml
+++ b/environment.yaml
@@ -14,6 +14,7 @@ dependencies:
   - jsonschema
   - networkx
   - requests
+  - crender >=0.5
   # test
   - make
   - pytest


### PR DESCRIPTION
Use crender as the recipe rendering method.

Current state: mostly OK.
- 2 crender failures while running the test suite on osx-arm64.
- test_compilers_must_be_in_build fails because crender expands the compiler jinja funciton to the actual packages.
- test_remove_python_pinning_good because crender adds pinning to python (and each package used).
- test_missing_build_number_good fails for no apparent good reason.
