### PR TITLE
Add uses_matplotlib lint

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -378,9 +378,10 @@ class gui_app(LintCheck):
 
 
 class uses_matplotlib(LintCheck):
-    """The recipe uses matplotlib, but matplotlib-base is recommended
+    """The recipe uses matplotlib, but matplotlib-base is always recommended.
     The ``matplotlib`` dependency should be replaced with ``matplotlib-base``
     unless the package explicitly needs the PyQt interactive plotting backend.
+    It will reduce the size of the package.
     """
 
     def check_recipe(self, recipe):

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -375,3 +375,14 @@ class gui_app(LintCheck):
     def check_recipe(self, recipe):
         if set(self.guis).intersection(set(recipe.get_deps("run"))):
             self.message(severity=INFO)
+
+
+class uses_matplotlib(LintCheck):
+    """The recipe uses matplotlib, but matplotlib-base is recommended
+    The ``matplotlib`` dependency should be replaced with ``matplotlib-base``
+    unless the package explicitly needs the PyQt interactive plotting backend.
+    """
+
+    def check_recipe(self, recipe):
+        if "matplotlib" in recipe.get_deps("run"):
+            self.message(severity=WARNING)

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -386,4 +386,4 @@ class uses_matplotlib(LintCheck):
 
     def check_recipe(self, recipe):
         if "matplotlib" in recipe.get_deps("run"):
-            self.message(severity=WARNING)
+            self.message(severity=INFO)

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -84,6 +84,8 @@ unknown_check
 
 unknown_selector
 
+uses_matplotlib
+
 uses_setuptools
 
 version_constraints_missing_whitespace

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -715,3 +715,31 @@ def test_gui_app_bad(base_yaml):
         assert (
             len(messages) == 1 and "GUI application" in messages[0].title
         ), f"Check failed for {gui}"
+
+
+def test_matplotlib_good(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        requirements:
+          run:
+            - matplotlib-base
+        """
+    )
+    lint_check = "uses_matplotlib"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_matplotlib_bad(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        requirements:
+          run:
+            - matplotlib
+        """
+    )
+    lint_check = "uses_matplotlib"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 1 and "The recipe uses matplotlib" in messages[0].title


### PR DESCRIPTION
Rationale:
- If the recipe uses the `matplotlib` dependency in `requirements/run` it should be replaced with `matplotlib-base` unless the package explicitly needs the `PyQt` interactive plotting backend.

TODO:
1. The same can be applied to `test/requires`