### PR TITLE
Add format to LintCheck messages

### DIFF
--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -302,6 +302,7 @@ class LintCheck(metaclass=LintCheckMeta):
 
     def message(
         self,
+        *args,
         section: str = None,
         severity: Severity = SEVERITY_DEFAULT,
         fname: str = None,
@@ -326,7 +327,14 @@ class LintCheck(metaclass=LintCheckMeta):
           output: the output the error occurred in (multi-output recipes only)
         """
         message = self.make_message(
-            self.recipe, section, severity, fname, line, data is not None, output
+            *args,
+            recipe=self.recipe,
+            section=section,
+            severity=severity,
+            fname=fname,
+            line=line,
+            canfix=data is not None,
+            output=output,
         )
         if data is not None and self.try_fix and self.fix(message, data):
             return
@@ -335,6 +343,7 @@ class LintCheck(metaclass=LintCheckMeta):
     @classmethod
     def make_message(
         cls,
+        *args,
         recipe: _recipe.Recipe,
         section: str = None,
         severity: Severity = SEVERITY_DEFAULT,
@@ -358,6 +367,8 @@ class LintCheck(metaclass=LintCheckMeta):
         doc = inspect.getdoc(cls)
         doc = doc.replace("::", ":").replace("``", "`")
         title, _, body = doc.partition("\n")
+        if len(args) > 0:
+            title = title.format(*args)
         if output >= 0:
             name = recipe.get(f"outputs/{output}/name", "")
             if name != "":

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -400,7 +400,9 @@ class missing_python(LintCheck):
                 if is_pypi or "pip install" in self.recipe.get(f"outputs/{o}/script", ""):
                     for section in ["host", "run"]:
                         if "python" not in recipe.get(f"outputs/{o}/requirements/{section}", ""):
-                            self.message(section, section=f"outputs/{o}/requirements/{section}", output=o)
+                            self.message(
+                                section, section=f"outputs/{o}/requirements/{section}", output=o
+                            )
         elif is_pypi or "pip install" in self.recipe.get("build/script", ""):
             for section in ["host", "run"]:
                 if "python" not in recipe.get(f"requirements/{section}", ""):

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -393,12 +393,6 @@ class missing_python(LintCheck):
           - python
     """
 
-    def _create_message(self, section, output=-1):
-        reset_text = self.__class__.__doc__
-        self.__class__.__doc__ = self.__class__.__doc__.format(section)
-        self.message(section=section, output=output)
-        self.__class__.__doc__ = reset_text
-
     def check_recipe(self, recipe):
         is_pypi = is_pypi_source(recipe)
         if outputs := recipe.get("outputs", None):
@@ -406,11 +400,11 @@ class missing_python(LintCheck):
                 if is_pypi or "pip install" in self.recipe.get(f"outputs/{o}/script", ""):
                     for section in ["host", "run"]:
                         if "python" not in recipe.get(f"outputs/{o}/requirements/{section}", ""):
-                            self._create_message(f"outputs/{o}/requirements/{section}", output=o)
+                            self.message(section, section=f"outputs/{o}/requirements/{section}", output=o)
         elif is_pypi or "pip install" in self.recipe.get("build/script", ""):
             for section in ["host", "run"]:
                 if "python" not in recipe.get(f"requirements/{section}", ""):
-                    self._create_message(f"requirements/{section}")
+                    self.message(section, section=f"requirements/{section}")
 
 
 class remove_python_pinning(LintCheck):

--- a/anaconda_linter/lint/check_spdx.py
+++ b/anaconda_linter/lint/check_spdx.py
@@ -58,27 +58,23 @@ class incorrect_license(LintCheck):
             expected_exceptions = {l.strip() for l in expected_exceptions}  # noqa
         non_spdx_licenses = set(filtered_licenses) - expected_licenses
         if non_spdx_licenses:
-            reset_text = self.__class__.__doc__
             for license in non_spdx_licenses:
                 closest = utils.find_closest_match(license)
                 if closest:
-                    self.__class__.__doc__ = self.__class__.__doc__.format(
+                    message_text = (
                         "The recipe's `about/license` key is not an SPDX compliant"
                         f" license or license exception, closest match: {closest}"
                     )
                 else:
-                    self.__class__.__doc__ = self.__class__.__doc__.format(
+                    message_text = (
                         "The recipe's `about/license` key is not an SPDX compliant"
                         " license or license exception, reference https://spdx.org/licenses/"
                     )
-                self.message(section="about/license")
-                self.__class__.__doc__ = reset_text
+                self.message(message_text, section="about/license")
         non_spdx_exceptions = set(parsed_exceptions) - expected_exceptions
         if non_spdx_exceptions:
-            reset_text = self.__class__.__doc__
-            self.__class__.__doc__ = self.__class__.__doc__.format(
+            message_text = (
                 "The recipe's `about/license` key is not an SPDX compliant license"
                 " or license exception, reference https://spdx.org/licenses/exceptions-index.html"
             )
-            self.message(section="about/license")
-            self.__class__.__doc__ = reset_text
+            self.message(message_text, section="about/license")

--- a/anaconda_linter/lint/check_url.py
+++ b/anaconda_linter/lint/check_url.py
@@ -33,11 +33,8 @@ class invalid_url(LintCheck):
                     ):
                         return
             if response_data["code"] < 0 or response_data["code"] >= 400:
-                self.__class__.__doc__ = self.__class__.__doc__.format(
-                    url, response_data["message"]
-                )
                 severity = INFO if "domain_redirect" in response_data else ERROR
-                self.message(section=section, severity=severity)
+                self.message(url, response_data["message"], section=section, severity=severity)
 
     def check_recipe(self, recipe):
         url_fields = [
@@ -52,13 +49,10 @@ class invalid_url(LintCheck):
             if url:
                 response_data = utils.check_url(url)
                 if response_data["code"] < 0 or response_data["code"] >= 400:
-                    reset_text = self.__class__.__doc__
-                    self.__class__.__doc__ = self.__class__.__doc__.format(
-                        url, response_data["message"]
-                    )
                     severity = INFO if "domain_redirect" in response_data else ERROR
-                    self.message(section=url_field, severity=severity)
-                    self.__class__.__doc__ = reset_text
+                    self.message(
+                        url, response_data["message"], section=url_field, severity=severity
+                    )
 
 
 class http_url(LintCheck):
@@ -71,8 +65,7 @@ class http_url(LintCheck):
     def check_source(self, source, section):
         url = source.get("url", "")
         if url.lower().startswith("http://"):
-            self.__class__.__doc__ = self.__class__.__doc__.format(url)
-            self.message(section=section)
+            self.message(url, section=section)
 
     def check_recipe(self, recipe):
         url_fields = [
@@ -85,7 +78,4 @@ class http_url(LintCheck):
         for url_field in url_fields:
             url = recipe.get(url_field, "")
             if url.lower().startswith("http://"):
-                reset_text = self.__class__.__doc__
-                self.__class__.__doc__ = self.__class__.__doc__.format(url)
-                self.message(section=url_field.split("/")[0], severity=WARNING)
-                self.__class__.__doc__ = reset_text
+                self.message(url, section=url_field.split("/")[0], severity=WARNING)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -9,29 +9,29 @@ from anaconda_linter.recipe import Recipe, RecipeError
 
 
 class dummy_info(lint.LintCheck):
-    """Info message
-    """
+    """Info message"""
+
     def check_recipe(self, recipe):
         self.message(severity=INFO)
 
 
 class dummy_warning(lint.LintCheck):
-    """Warning message
-    """
+    """Warning message"""
+
     def check_recipe(self, recipe):
         self.message(severity=WARNING)
 
 
 class dummy_error(lint.LintCheck):
-    """Error message
-    """
+    """Error message"""
+
     def check_recipe(self, recipe):
         self.message(severity=ERROR)
 
 
 class dummy_error_format(lint.LintCheck):
-    """{} message of severity {}
-    """
+    """{} message of severity {}"""
+
     def check_recipe(self, recipe):
         self.message("Dummy", "ERROR")
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -10,18 +10,31 @@ from anaconda_linter.recipe import Recipe, RecipeError
 
 
 class dummy_info(lint.LintCheck):
+    """Info message
+    """
     def check_recipe(self, recipe):
-        self.message("Info message", severity=INFO)
+        self.message(severity=INFO)
 
 
 class dummy_warning(lint.LintCheck):
+    """Warning message
+    """
     def check_recipe(self, recipe):
-        self.message("Warning message", severity=WARNING)
+        self.message(severity=WARNING)
 
 
 class dummy_error(lint.LintCheck):
+    """Error message
+    """
     def check_recipe(self, recipe):
-        self.message("Error message", severity=ERROR)
+        self.message(severity=ERROR)
+
+
+class dummy_error_format(lint.LintCheck):
+    """{} message of severity {}
+    """
+    def check_recipe(self, recipe):
+        self.message("Dummy", "ERROR")
 
 
 def test_only_lint(base_yaml, linter):
@@ -228,3 +241,15 @@ def test_error_report_line(base_yaml):
     lint_check = "incorrect_license"
     messages = check(lint_check, yaml_str)
     assert len(messages) == 1 and messages[0].start_line == 5
+
+
+def test_message_title(base_yaml):
+    lint_check = "dummy_error"
+    messages = check(lint_check, base_yaml)
+    assert len(messages) == 1 and messages[0].title == "Error message"
+
+
+def test_message_title_format(base_yaml):
+    lint_check = "dummy_error_format"
+    messages = check(lint_check, base_yaml)
+    assert len(messages) == 1 and messages[0].title == "Dummy message of severity ERROR"

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 
 import pytest
 from conftest import check
@@ -81,7 +80,7 @@ def test_lint_none(base_yaml, linter):
     assert return_code == 0 and len(linter.get_messages()) == 0
 
 
-def test_lint_file(base_yaml, linter):
+def test_lint_file(base_yaml, linter, tmpdir):
     yaml_str = (
         base_yaml
         + """
@@ -92,14 +91,13 @@ def test_lint_file(base_yaml, linter):
             - dummy_warning
         """
     )
-    with tempfile.TemporaryDirectory() as tmpdir:
-        recipe_dir = os.path.join(tmpdir, "recipe")
-        os.mkdir(recipe_dir)
-        meta_yaml = os.path.join(recipe_dir, "meta.yaml")
-        with open(meta_yaml, "w") as f:
-            f.write(yaml_str)
-        linter.lint([recipe_dir])
-        assert len(linter.get_messages()) == 3
+    recipe_dir = os.path.join(tmpdir, "recipe")
+    os.mkdir(recipe_dir)
+    meta_yaml = os.path.join(recipe_dir, "meta.yaml")
+    with open(meta_yaml, "w") as f:
+        f.write(yaml_str)
+    linter.lint([recipe_dir])
+    assert len(linter.get_messages()) == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR removes the current `reset_text` way to use dynamic messages. This should result in less repetitive code while we still use the doc strings for messages.