### PR TITLE
Update multi-output checks

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -336,6 +336,12 @@ class missing_pip_check(LintCheck):
     """
 
     def _check_file(self, file, output=-1):
+        """Reads the file for a `pip check` command and outputs a message if not found.
+
+        Args:
+          file: The path of the file.
+          output: The output number for multi-output recipes.
+        """
         if os.path.isfile(file):
             with open(file) as test_file:
                 for line in test_file:

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -144,6 +144,13 @@ class missing_tests(LintCheck):
     and/or any file named ``run_test.py`, ``run_test.sh`` or
     ``run_test.pl`` executing tests.
 
+    For multi-output recipes, add:
+
+      test:
+        script: <test file>
+
+    to each output
+
     """
 
     test_files = ["run_test.py", "run_test.sh", "run_test.pl"]

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -161,7 +161,8 @@ class missing_tests(LintCheck):
     def check_recipe(self, recipe):
         if outputs := recipe.get("outputs", None):
             for o in range(len(outputs)):
-                self.check_output(recipe, f"outputs/{o}/")
+                if not recipe.get(f"outputs/{o}/test/script", ""):
+                    self.check_output(recipe, f"outputs/{o}/")
         # multi-output recipes do not execute test files automatically
         elif not any(os.path.exists(os.path.join(recipe.dir, f)) for f in self.test_files):
             self.check_output(recipe)

--- a/anaconda_linter/lint/check_multi_output.py
+++ b/anaconda_linter/lint/check_multi_output.py
@@ -44,3 +44,15 @@ class no_global_test(LintCheck):
     def check_recipe(self, recipe):
         if recipe.get("outputs", None) and recipe.get("test", None):
             self.message(severity=WARNING)
+
+
+class output_missing_script(LintCheck):
+    """Output is missing script.
+
+    Every output must have either a filename or a command in the script field.
+    """
+
+    def check_recipe(self, recipe):
+        for o in range(len(recipe.get("outputs", []))):
+            if recipe.get(f"outputs/{o}/script", "") == "":
+                self.message(output=o)

--- a/anaconda_linter/lint/check_multi_output.py
+++ b/anaconda_linter/lint/check_multi_output.py
@@ -53,7 +53,22 @@ class output_missing_script(LintCheck):
     """
 
     def check_recipe(self, recipe):
+        # May not need scripts if pin_subpackage is used.
+        # Pinned subpackages are expanded to their names.
+        outputs = recipe.get("outputs", [])
+        output_names = {recipe.get(f"outputs/{n}/name", None) for n in range(len(outputs))}
+        deps = recipe.get_deps_dict("run")
+        subpackages = output_names.intersection(set(deps.keys()))
+        print(subpackages)
+        print(deps)
         for o in range(len(recipe.get("outputs", []))):
+            # True if subpackage is a run dependency
+            if any(
+                path.startswith(f"outputs/{o}/")
+                for name in subpackages
+                for path in deps[name]["paths"]
+            ):
+                continue
             if recipe.get(f"outputs/{o}/script", "") == "":
                 self.message(output=o)
 

--- a/anaconda_linter/lint/check_multi_output.py
+++ b/anaconda_linter/lint/check_multi_output.py
@@ -56,3 +56,13 @@ class output_missing_script(LintCheck):
         for o in range(len(recipe.get("outputs", []))):
             if recipe.get(f"outputs/{o}/script", "") == "":
                 self.message(output=o)
+
+
+class output_script_name_default(LintCheck):
+    """Output should not use default script names build.sh/bld.sh."""
+
+    def check_recipe(self, recipe):
+        default_scripts = ("build.sh", "bld.bat")
+        for o in range(len(recipe.get("outputs", []))):
+            if recipe.get(f"outputs/{o}/script", "") in default_scripts:
+                self.message(output=o)

--- a/anaconda_linter/lint/check_multi_output.py
+++ b/anaconda_linter/lint/check_multi_output.py
@@ -59,8 +59,6 @@ class output_missing_script(LintCheck):
         output_names = {recipe.get(f"outputs/{n}/name", None) for n in range(len(outputs))}
         deps = recipe.get_deps_dict("run")
         subpackages = output_names.intersection(set(deps.keys()))
-        print(subpackages)
-        print(deps)
         for o in range(len(recipe.get("outputs", []))):
             # True if subpackage is a run dependency
             if any(

--- a/anaconda_linter/lint/check_multi_output.py
+++ b/anaconda_linter/lint/check_multi_output.py
@@ -72,7 +72,7 @@ class output_missing_script(LintCheck):
 
 
 class output_script_name_default(LintCheck):
-    """Output should not use default script names build.sh/bld.sh."""
+    """Output should not use default script names build.sh/bld.bat."""
 
     def check_recipe(self, recipe):
         default_scripts = ("build.sh", "bld.bat")

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -76,6 +76,8 @@ output_missing_name
 
 output_missing_script
 
+output_script_name_default
+
 outputs_not_unique
 
 patch_must_be_in_build

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -74,6 +74,8 @@ non_url_source
 
 output_missing_name
 
+output_missing_script
+
 outputs_not_unique
 
 patch_must_be_in_build

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -758,19 +758,6 @@ def test_has_run_test_and_commands_good_cmd(base_yaml, tmpdir):
 
 
 def test_has_run_test_and_commands_good_script(base_yaml, tmpdir):
-    yaml_str = (
-        base_yaml
-        + """
-        test:
-          script: test_module.sh
-        """
-    )
-    lint_check = "has_run_test_and_commands"
-    messages = check_dir(lint_check, tmpdir, yaml_str)
-    assert len(messages) == 0
-
-
-def test_has_run_test_and_commands_good_script_default(base_yaml, tmpdir):
     lint_check = "has_run_test_and_commands"
     recipe_dir = os.path.join(tmpdir, "recipe")
     os.mkdir(recipe_dir)
@@ -952,27 +939,6 @@ def test_missing_pip_check_pip_install_script_good(base_yaml, tmpdir):
           url: https://github.com/joblib/joblib/archive/1.1.1.tar.gz
         build:
           script: {{ PYTHON }} -m pip install .
-        test:
-          script: test_package.sh
-        """
-    )
-    lint_check = "missing_pip_check"
-    recipe_dir = os.path.join(tmpdir, "recipe")
-    os.mkdir(recipe_dir)
-    with open(os.path.join(recipe_dir, "test_package.sh"), "w") as f:
-        f.write("pip check\n")
-    messages = check_dir(lint_check, tmpdir, yaml_str)
-    assert len(messages) == 0
-
-
-def test_missing_pip_check_pip_install_script_default_good(base_yaml, tmpdir):
-    yaml_str = (
-        base_yaml
-        + """
-        source:
-          url: https://github.com/joblib/joblib/archive/1.1.1.tar.gz
-        build:
-          script: {{ PYTHON }} -m pip install .
         """
     )
     lint_check = "missing_pip_check"
@@ -1087,46 +1053,6 @@ def test_missing_pip_check_pip_install_cmd_bad_multi(base_yaml):
 
 
 def test_missing_pip_check_pip_install_script_bad(base_yaml, tmpdir):
-    yaml_str = (
-        base_yaml
-        + """
-        source:
-          url: https://github.com/joblib/joblib/archive/1.1.1.tar.gz
-        build:
-          script: {{ PYTHON }} -m pip install .
-        test:
-          script: test_package.sh
-        """
-    )
-    lint_check = "missing_pip_check"
-    recipe_dir = os.path.join(tmpdir, "recipe")
-    os.mkdir(recipe_dir)
-    with open(os.path.join(recipe_dir, "test_package.sh"), "w") as f:
-        f.write("other_test_command\n")
-    messages = check_dir(lint_check, tmpdir, yaml_str)
-    assert len(messages) == 1 and "pip check should be present" in messages[0].title
-
-
-def test_missing_pip_check_pip_install_script_missing(base_yaml, tmpdir):
-    yaml_str = (
-        base_yaml
-        + """
-        source:
-          url: https://github.com/joblib/joblib/archive/1.1.1.tar.gz
-        build:
-          script: {{ PYTHON }} -m pip install .
-        test:
-          script: test_package.sh
-        """
-    )
-    lint_check = "missing_pip_check"
-    recipe_dir = os.path.join(tmpdir, "recipe")
-    os.mkdir(recipe_dir)
-    messages = check_dir(lint_check, tmpdir, yaml_str)
-    assert len(messages) == 1 and "pip check should be present" in messages[0].title
-
-
-def test_missing_pip_check_pip_install_script_default_bad(base_yaml, tmpdir):
     yaml_str = (
         base_yaml
         + """

--- a/tests/test_multi_output.py
+++ b/tests/test_multi_output.py
@@ -152,3 +152,36 @@ def test_output_missing_script_bad(base_yaml):
     lint_check = "output_missing_script"
     messages = check(lint_check, yaml_str)
     assert len(messages) == 2 and all("Output is missing script" in msg.title for msg in messages)
+
+
+def test_output_script_name_default_good(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        outputs:
+          - name: output1
+            script: build_output1.sh
+          - name: output2
+            script: build_output2.sh
+        """
+    )
+    lint_check = "output_script_name_default"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+@pytest.mark.parametrize("script", ("build.sh", "bld.bat"))
+def test_output_script_name_default_bad(base_yaml, script):
+    yaml_str = (
+        base_yaml
+        + f"""
+        outputs:
+          - name: output1
+            script: {script}
+          - name: output2
+            script: {script}
+        """
+    )
+    lint_check = "output_script_name_default"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 2 and all("default script names" in msg.title for msg in messages)

--- a/tests/test_multi_output.py
+++ b/tests/test_multi_output.py
@@ -141,6 +141,28 @@ def test_output_missing_script_good(base_yaml):
     assert len(messages) == 0
 
 
+def test_output_missing_script_subpackage(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        outputs:
+          - name: output1
+            script: build_output1.sh
+            requirements:
+              run:
+                - python
+          - name: output2
+            requirements:
+              run:
+                - python
+                - {{ pin_subpackage('output1') }}
+        """
+    )
+    lint_check = "output_missing_script"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
 def test_output_missing_script_bad(base_yaml):
     yaml_str = (
         base_yaml

--- a/tests/test_multi_output.py
+++ b/tests/test_multi_output.py
@@ -122,3 +122,33 @@ def test_no_global_test_bad(base_yaml):
     lint_check = "no_global_test"
     messages = check(lint_check, yaml_str)
     assert len(messages) == 1 and "Global tests" in messages[0].title
+
+
+def test_output_missing_script_good(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        outputs:
+          - name: output1
+            script: build_output1.sh
+          - name: output2
+            script: build_output2.sh
+        """
+    )
+    lint_check = "output_missing_script"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_output_missing_script_bad(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        outputs:
+          - name: output1
+          - name: output2
+        """
+    )
+    lint_check = "output_missing_script"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 2 and all("Output is missing script" in msg.title for msg in messages)

--- a/tests/test_multi_output.py
+++ b/tests/test_multi_output.py
@@ -1,3 +1,4 @@
+import pytest
 from conftest import check
 
 


### PR DESCRIPTION
Expand and fix checks for multi-output recipes.

# Changes

* Add check for multi-output script names
* Add check to ensure that each output has a script section
* Fix multi-output test script checks
* Remove checking the `test/script` field for single-output recipes since they are not used by `conda-build`.