### PR TITLE
Update URL checks

### DIFF
--- a/anaconda_linter/lint/check_url.py
+++ b/anaconda_linter/lint/check_url.py
@@ -19,22 +19,9 @@ class invalid_url(LintCheck):
         url = source.get("url", "")
         if url:
             response_data = utils.check_url(url)
-            acceptable_redirects = [
-                ("pypi.io", "pypi.org"),
-                ("pypi.org", "files.pythonhosted.org"),
-                ("github.com", "objects.githubusercontent.com"),
-                ("github.com", "codeload.github.com"),
-            ]
-            if response_data["code"] < 0 and "domain_redirect" in response_data:
-                for redir in acceptable_redirects:
-                    if (
-                        response_data["domain_origin"] == redir[0]
-                        and response_data["domain_redirect"] == redir[1]
-                    ):
-                        return
             if response_data["code"] < 0 or response_data["code"] >= 400:
-                severity = INFO if "domain_redirect" in response_data else ERROR
-                self.message(url, response_data["message"], section=section, severity=severity)
+                if "domain_redirect" not in response_data:
+                    self.message(url, response_data["message"], section=section)
 
     def check_recipe(self, recipe):
         url_fields = [

--- a/anaconda_linter/lint/check_url.py
+++ b/anaconda_linter/lint/check_url.py
@@ -5,7 +5,7 @@ Verify that the URLs in the recipe are valid
 """
 
 from .. import utils
-from . import ERROR, INFO, WARNING, LintCheck
+from . import ERROR, INFO, LintCheck
 
 
 class invalid_url(LintCheck):
@@ -45,14 +45,21 @@ class invalid_url(LintCheck):
 class http_url(LintCheck):
     """{} is not https
 
-    Please replace with https if possible.
+    Please replace with https.
 
     """
 
+    def _check_url(self, url, section):
+        if url.lower().startswith("http://"):
+            # Check if the https source even exists
+            https_response = utils.check_url(url.lower().replace("http://", "http://"))
+            if https_response["code"] < 400:
+                self.message(url, section=section)
+
     def check_source(self, source, section):
         url = source.get("url", "")
-        if url.lower().startswith("http://"):
-            self.message(url, section=section)
+        if url != "":
+            self._check_url(url, section)
 
     def check_recipe(self, recipe):
         url_fields = [
@@ -64,5 +71,4 @@ class http_url(LintCheck):
         ]
         for url_field in url_fields:
             url = recipe.get(url_field, "")
-            if url.lower().startswith("http://"):
-                self.message(url, section=url_field.split("/")[0], severity=WARNING)
+            self._check_url(url, url_field.split("/")[0])

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -51,6 +51,29 @@ def test_invalid_url_good_redirect(base_yaml):
         "dev_url",
     ),
 )
+def test_invalid_url_about_good(base_yaml, url_field):
+    lint_check = "invalid_url"
+    yaml_str = (
+        base_yaml
+        + f"""
+        about:
+          {url_field}: https://sqlite.org/
+        """
+    )
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+@pytest.mark.parametrize(
+    "url_field",
+    (
+        "home",
+        "doc_url",
+        "doc_source_url",
+        "license_url",
+        "dev_url",
+    ),
+)
 def test_invalid_url_about_bad(base_yaml, url_field):
     lint_check = "invalid_url"
     yaml_str = (
@@ -60,42 +83,6 @@ def test_invalid_url_about_bad(base_yaml, url_field):
           {url_field}: https://sqlit.org/
         """
     )
-    messages = check(lint_check, yaml_str)
-    assert len(messages) == 1
-
-
-@pytest.mark.parametrize(
-    "url",
-    (
-        "https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz",
-        "https://pypi.org/packages/source/D/Django/Django-4.1.tar.gz",
-        "https://github.com/beekeeper-studio/beekeeper-studio/releases/"
-        "download/v3.6.2/Beekeeper-Studio-3.6.2-portable.exe",
-        "https://github.com/joblib/joblib/archive/1.1.1.tar.gz",
-    ),
-)
-def test_invalid_url_redirect_good(base_yaml, url):
-    lint_check = "invalid_url"
-    yaml_str = (
-        base_yaml
-        + f"""
-        source:
-          url: {url}
-            """
-    )
-    messages = check(lint_check, yaml_str)
-    assert len(messages) == 0
-
-
-def test_invalid_url_redirect_bad(base_yaml):
-    yaml_str = (
-        base_yaml
-        + """
-        source:
-          url: https://continuum.io
-        """
-    )
-    lint_check = "invalid_url"
     messages = check(lint_check, yaml_str)
     assert len(messages) == 1
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -28,6 +28,19 @@ def test_invalid_url_bad(base_yaml):
     assert len(messages) == 1
 
 
+def test_invalid_url_good_redirect(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/p/pydot/pydot-1.4.1.tar.gz
+        """
+    )
+    lint_check = "invalid_url"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
 @pytest.mark.parametrize(
     "url_field",
     (


### PR DESCRIPTION
Implement new recipe standards for URLs

# Changes

* Allow redirects for source URLs - there are too many to keep track of and they are constantly changing
* Check if an https version is available before warning about http URLs (not tested because I don't know of a source that fulfills the requirement)