### PR TITLE
Add checks for python packages

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -293,7 +293,12 @@ class avoid_noarch(LintCheck):
 
     def check_recipe(self, recipe):
         noarch = recipe.get("build/noarch", "")
-        if noarch == "python":
+        if (
+            noarch == "python"
+            and recipe.get("build/number", 0) == 0
+            and not recipe.get("build/osx_is_app", False)
+            and not recipe.get("app", None)
+        ):
             self.message(section="build", severity=WARNING)
 
 

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -134,27 +134,22 @@ class missing_wheel(LintCheck):
                         self.message(section=f"outputs/{o}/requirements/host", output=o)
 
 
-class setup_py_install_args(LintCheck):
-    """The recipe uses setuptools without required arguments
+class uses_setup_py(LintCheck):
+    """`python setup.py install` is deprecated.
 
     Please use::
 
-        $PYTHON setup.py install --single-version-externally-managed --record=record.txt
+        $PYTHON -m pip install . --no-deps
 
-    The parameters are required to avoid ``setuptools`` trying (and
-    failing) to install ``certifi`` when a package this recipe
-    requires defines entrypoints in its ``setup.py``.
-
+    Or use another python build tool.
     """
 
     @staticmethod
     def _check_line(line: str) -> bool:
         """Check a line for a broken call to setup.py"""
-        if "setup.py install" not in line:
-            return True
-        if "--single-version-externally-managed" in line:
-            return True
-        return False
+        if "setup.py install" in line:
+            return False
+        return True
 
     def check_deps(self, deps):
         if "setuptools" not in deps:
@@ -179,7 +174,7 @@ class setup_py_install_args(LintCheck):
                 with open(os.path.join(self.recipe.dir, build_file)) as buildsh:
                     for num, line in enumerate(buildsh):
                         if not self._check_line(line):
-                            self.message(fname="build.sh", line=num, output=output)
+                            self.message(fname=build_file, line=num, output=output)
             except FileNotFoundError:
                 pass
 

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -80,8 +80,9 @@ patch_must_be_in_build
 
 patch_unnecessary
 
-remove_python_pinning
+pip_install_args
 
+remove_python_pinning
 
 should_use_compilers
 

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -82,13 +82,14 @@ patch_unnecessary
 
 remove_python_pinning
 
-setup_py_install_args
 
 should_use_compilers
 
 unknown_check
 
 unknown_selector
+
+uses_setup_py
 
 uses_setuptools
 

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -62,6 +62,8 @@ missing_source
 
 missing_summary
 
+missing_test_requirement_pip
+
 missing_tests
 
 missing_version_or_name

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -745,6 +745,49 @@ def test_avoid_noarch_good(base_yaml):
     assert len(messages) == 0
 
 
+def test_avoid_noarch_good_build_number(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        build:
+          noarch: python
+          number: 2
+        """
+    )
+    lint_check = "avoid_noarch"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_avoid_noarch_good_osx_app(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        build:
+          noarch: python
+          osx_is_app: true
+        """
+    )
+    lint_check = "avoid_noarch"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_avoid_noarch_good_app(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        build:
+          noarch: python
+        app:
+          icon: logo.png
+        """
+    )
+    lint_check = "avoid_noarch"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
 def test_avoid_noarch_bad(base_yaml):
     yaml_str = (
         base_yaml

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -1338,6 +1338,241 @@ def test_missing_pip_check_pip_install_script_bad_multi(base_yaml, tmpdir):
     )
 
 
+def test_missing_test_requirement_pip_missing(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_missing_test_requirement_pip_missing_multi(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        outputs:
+          - name: output1
+          - name: output2
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_missing_test_requirementk_pip_script_missing(base_yaml, tmpdir):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    recipe_dir = os.path.join(tmpdir, "recipe")
+    os.mkdir(recipe_dir)
+    with open(os.path.join(recipe_dir, "run_test.sh"), "w") as f:
+        f.write("some_other_command\n")
+    messages = check_dir(lint_check, tmpdir, yaml_str)
+    assert len(messages) == 0
+
+
+def test_missing_test_requirement_pip_script_missing_multi(base_yaml, tmpdir):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        outputs:
+          - name: output1
+          - name: output2
+            test:
+              script: test_output.sh
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    recipe_dir = os.path.join(tmpdir, "recipe")
+    os.mkdir(recipe_dir)
+    with open(os.path.join(recipe_dir, "test_output.sh"), "w") as f:
+        f.write("some_other_command\n")
+    messages = check_dir(lint_check, tmpdir, yaml_str)
+    assert len(messages) == 0
+
+
+def test_missing_test_requirement_pip_cmd_good(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        test:
+          commands:
+            - pip check
+          requires:
+            - pip
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_missing_test_requirement_pip_cmd_good_multi(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        outputs:
+          - name: output1
+            test:
+              commands:
+                - pip check
+              requires:
+                - pip
+          - name: output2
+            test:
+              commands:
+                - pip check
+              requires:
+                - pip
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_missing_test_requirement_pip_script_good(base_yaml, tmpdir):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        test:
+          requires:
+            - pip
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    recipe_dir = os.path.join(tmpdir, "recipe")
+    os.mkdir(recipe_dir)
+    with open(os.path.join(recipe_dir, "run_test.sh"), "w") as f:
+        f.write("pip check\n")
+    messages = check_dir(lint_check, tmpdir, yaml_str)
+    assert len(messages) == 0
+
+
+def test_missing_test_requirement_pip_script_good_multi(base_yaml, tmpdir):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        outputs:
+          - name: output1
+          - name: output2
+            test:
+              script: test_output.sh
+              requires:
+                - pip
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    recipe_dir = os.path.join(tmpdir, "recipe")
+    os.mkdir(recipe_dir)
+    with open(os.path.join(recipe_dir, "test_output.sh"), "w") as f:
+        f.write("pip check\n")
+    messages = check_dir(lint_check, tmpdir, yaml_str)
+    assert len(messages) == 0
+
+
+def test_missing_test_requirement_pip_cmd_bad(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        test:
+          commands:
+            - pip check
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 1 and "pip is required" in messages[0].title
+
+
+def test_missing_test_requirement_pip_cmd_bad_multi(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        outputs:
+          - name: output1
+            test:
+              commands:
+                - pip check
+          - name: output2
+            test:
+              commands:
+                - pip check
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 2 and all("pip is required" in msg.title for msg in messages)
+
+
+def test_missing_test_requirement_pip_script_bad(base_yaml, tmpdir):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    recipe_dir = os.path.join(tmpdir, "recipe")
+    os.mkdir(recipe_dir)
+    with open(os.path.join(recipe_dir, "run_test.sh"), "w") as f:
+        f.write("pip check\n")
+    messages = check_dir(lint_check, tmpdir, yaml_str)
+    assert len(messages) == 1 and "pip is required" in messages[0].title
+
+
+def test_missing_test_requirement_pip_script_bad_multi(base_yaml, tmpdir):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        outputs:
+          - name: output1
+            test:
+              script: test_output.sh
+          - name: output2
+            test:
+              script: test_output.sh
+        """
+    )
+    lint_check = "missing_test_requirement_pip"
+    recipe_dir = os.path.join(tmpdir, "recipe")
+    os.mkdir(recipe_dir)
+    with open(os.path.join(recipe_dir, "test_output.sh"), "w") as f:
+        f.write("pip check\n")
+    messages = check_dir(lint_check, tmpdir, yaml_str)
+    assert len(messages) == 2 and all("pip is required" in msg.title for msg in messages)
+
+
 def test_missing_python_url_good(base_yaml):
     yaml_str = (
         base_yaml

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -334,29 +334,29 @@ def test_missing_wheel_pip_install_bad_multi(base_yaml):
     assert len(messages) == 2 and all("wheel should be present" in msg.title for msg in messages)
 
 
-def test_setup_py_install_args_good_missing(base_yaml):
-    lint_check = "setup_py_install_args"
+def test_uses_setup_py_good_missing(base_yaml):
+    lint_check = "uses_setup_py"
     messages = check(lint_check, base_yaml)
     assert len(messages) == 0
 
 
-def test_setup_py_install_args_good_cmd(base_yaml):
+def test_uses_setup_py_good_cmd(base_yaml):
     yaml_str = (
         base_yaml
         + """
         build:
-          script: {{ PYTHON }} -m setup.py install --single-version-externally-managed
+          script: {{ PYTHON }} -m pip install . --no-deps
         requirements:
           host:
             - setuptools
         """
     )
-    lint_check = "setup_py_install_args"
+    lint_check = "uses_setup_py"
     messages = check(lint_check, yaml_str)
     assert len(messages) == 0
 
 
-def test_setup_py_install_args_good_script(base_yaml, tmpdir):
+def test_uses_setup_py_good_script(base_yaml, tmpdir):
     yaml_str = (
         base_yaml
         + """
@@ -365,16 +365,16 @@ def test_setup_py_install_args_good_script(base_yaml, tmpdir):
             - setuptools
         """
     )
-    lint_check = "setup_py_install_args"
+    lint_check = "uses_setup_py"
     recipe_dir = os.path.join(tmpdir, "recipe")
     os.mkdir(recipe_dir)
     with open(os.path.join(recipe_dir, "build.sh"), "w") as f:
-        f.write("{{ PYTHON }} -m setup.py install --single-version-externally-managed\n")
+        f.write("{{ PYTHON }} -m pip install . --no-deps\n")
     messages = check_dir(lint_check, tmpdir, yaml_str)
     assert len(messages) == 0
 
 
-def test_setup_py_install_args_bad_cmd(base_yaml):
+def test_uses_setup_py_bad_cmd(base_yaml):
     yaml_str = (
         base_yaml
         + """
@@ -385,12 +385,12 @@ def test_setup_py_install_args_bad_cmd(base_yaml):
             - setuptools
         """
     )
-    lint_check = "setup_py_install_args"
+    lint_check = "uses_setup_py"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and "setuptools without required arguments" in messages[0].title
+    assert len(messages) == 1 and "python setup.py install" in messages[0].title
 
 
-def test_setup_py_install_args_bad_cmd_multi(base_yaml):
+def test_uses_setup_py_bad_cmd_multi(base_yaml):
     yaml_str = (
         base_yaml
         + """
@@ -407,14 +407,12 @@ def test_setup_py_install_args_bad_cmd_multi(base_yaml):
                 - setuptools
         """
     )
-    lint_check = "setup_py_install_args"
+    lint_check = "uses_setup_py"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 2 and all(
-        "setuptools without required arguments" in msg.title for msg in messages
-    )
+    assert len(messages) == 2 and all("python setup.py install" in msg.title for msg in messages)
 
 
-def test_setup_py_install_args_bad_script(base_yaml, tmpdir):
+def test_uses_setup_py_bad_script(base_yaml, tmpdir):
     yaml_str = (
         base_yaml
         + """
@@ -423,16 +421,16 @@ def test_setup_py_install_args_bad_script(base_yaml, tmpdir):
             - setuptools
         """
     )
-    lint_check = "setup_py_install_args"
+    lint_check = "uses_setup_py"
     recipe_dir = os.path.join(tmpdir, "recipe")
     os.mkdir(recipe_dir)
     with open(os.path.join(recipe_dir, "build.sh"), "w") as f:
         f.write("{{ PYTHON }} -m setup.py install\n")
     messages = check_dir(lint_check, tmpdir, yaml_str)
-    assert len(messages) == 1 and "setuptools without required arguments" in messages[0].title
+    assert len(messages) == 1 and "python setup.py install" in messages[0].title
 
 
-def test_setup_py_install_args_bad_script_multi(base_yaml, tmpdir):
+def test_uses_setup_py_bad_script_multi(base_yaml, tmpdir):
     yaml_str = (
         base_yaml
         + """
@@ -449,15 +447,13 @@ def test_setup_py_install_args_bad_script_multi(base_yaml, tmpdir):
                 - setuptools
         """
     )
-    lint_check = "setup_py_install_args"
+    lint_check = "uses_setup_py"
     recipe_dir = os.path.join(tmpdir, "recipe")
     os.mkdir(recipe_dir)
     with open(os.path.join(recipe_dir, "build_output.sh"), "w") as f:
         f.write("{{ PYTHON }} -m setup.py install\n")
     messages = check_dir(lint_check, tmpdir, yaml_str)
-    assert len(messages) == 2 and all(
-        "setuptools without required arguments" in msg.title for msg in messages
-    )
+    assert len(messages) == 2 and all("python setup.py install" in msg.title for msg in messages)
 
 
 def test_cython_must_be_in_host_good(base_yaml):


### PR DESCRIPTION
# Changes

* Disallow `python setup.py install`
* Enforce `--no-deps` option with `pip install`
* Allow `noarch:python` for rebuilds, osx apps, and GUI apps
* Check for pip in test requirements if `pip check` is executed in the tests