### PR TITLE
Add config.yaml to test directory

### DIFF
--- a/anaconda_linter/__init__.py
+++ b/anaconda_linter/__init__.py
@@ -1,5 +1,5 @@
 __name__ = "anaconda_linter"
-__version__ = "0.0.5"
+__version__ = "0.0.4"
 __author__ = "Anaconda, Inc."
 __email__ = "distribution_team@anaconda.com"
 __license__ = "BSD-3-Clause"

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -1,0 +1,5 @@
+requirements: requirements.txt
+blocklists:
+    - build-fail-blocklist
+channels:
+    - defaults

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from anaconda_linter.recipe import Recipe
 @pytest.fixture()
 def linter():
     """Sets up linter for use in other tests"""
-    config_file = os.path.abspath(os.path.dirname(__file__) + "/../anaconda_linter/config.yaml")
+    config_file = Path(__file__).parent / "config.yaml"
     config = utils.load_config(config_file)
     linter = Linter(config=config)
     return linter
@@ -36,7 +36,7 @@ def recipe_dir(tmpdir):
 
 
 def check(check_name, recipe_str):
-    config_file = Path(__file__).parent / "../anaconda_linter/config.yaml"
+    config_file = Path(__file__).parent / "config.yaml"
     config = utils.load_config(str(config_file.resolve()))
     linter = Linter(config=config)
     recipe = Recipe.from_string(recipe_str)
@@ -47,7 +47,7 @@ def check(check_name, recipe_str):
 def check_dir(check_name, feedstock_dir, recipe_str):
     if not isinstance(feedstock_dir, Path):
         feedstock_dir = Path(feedstock_dir)
-    config_file = Path(__file__).parent / "../anaconda_linter/config.yaml"
+    config_file = Path(__file__).parent / "config.yaml"
     config = utils.load_config(str(config_file.resolve()))
     linter = Linter(config=config)
     recipe_dir = feedstock_dir / "recipe"


### PR DESCRIPTION
The test environment needs to be self-consistent or conda-build will fail tests.

This PR adds a config file for tests.