### PR TITLE
Add recipe directory checks

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -487,7 +487,7 @@ class has_run_test_and_commands(LintCheck):
         else:
             if recipe.get("test/commands", []) and (
                 recipe.get("test/script", None)
-                or set(os.listdir(recipe.recipe_dir)).intersection(
+                or set(os.listdir(recipe.dir)).intersection(
                     {"run_test.sh", "run_test.pl", "run_test.bat"}
                 )
             ):
@@ -510,7 +510,7 @@ class has_imports_and_run_test_py(LintCheck):
                     self.message(section=f"{test_section}/imports", output=o)
         else:
             if recipe.get("test/imports", []) and os.path.isfile(
-                os.path.join(recipe.recipe_dir, "run_test.py")
+                os.path.join(recipe.dir, "run_test.py")
             ):
                 self.message(section="test/imports")
 
@@ -550,7 +550,7 @@ class missing_imports_or_run_test_py(LintCheck):
         elif (
             (is_pypi or "python" in deps)
             and not recipe.get("test/imports", [])
-            and not os.path.isfile(os.path.join(recipe.recipe_dir, "run_test.py"))
+            and not os.path.isfile(os.path.join(recipe.dir, "run_test.py"))
         ):
             self.message(section="test")
 
@@ -599,7 +599,7 @@ class missing_pip_check(LintCheck):
                     self.message(section="test/commands")
             else:
                 test_files = (
-                    set(os.listdir(recipe.recipe_dir)).intersection({"run_test.sh", "run_test.bat"})
+                    set(os.listdir(recipe.dir)).intersection({"run_test.sh", "run_test.bat"})
                     if os.path.exists(recipe.dir)
                     else set()
                 )
@@ -638,7 +638,7 @@ class missing_test_requirement_pip(LintCheck):
             return self._check_file(os.path.join(recipe.dir, script))
         else:
             test_files = (
-                set(os.listdir(recipe.recipe_dir)).intersection({"run_test.sh", "run_test.bat"})
+                set(os.listdir(recipe.dir)).intersection({"run_test.sh", "run_test.bat"})
                 if os.path.exists(recipe.dir)
                 else set()
             )

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -213,7 +213,9 @@ class missing_tests(LintCheck):
                 if not recipe.get(f"outputs/{o}/test/script", ""):
                     self.check_output(recipe, f"outputs/{o}/")
         # multi-output recipes do not execute test files automatically
-        elif not any(os.path.exists(os.path.join(recipe.dir, f)) for f in self.test_files):
+        elif not (
+            recipe.dir and any(os.path.exists(os.path.join(recipe.dir, f)) for f in self.test_files)
+        ):
             self.check_output(recipe)
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,10 +40,8 @@ test:
     - anaconda_linter
   commands:
     - pip check
-    # pytest fails when called directly from the conda test environment,
-    # but not when inside the tests directory
     # lint_list is only an important test for development
-    - cd tests && python -m pytest . -k 'not lint_list'
+    - python -m pytest -vv tests -k 'not lint_list'
 
 about:
   home: https://github.com/anaconda-distribution/anaconda-linter


### PR DESCRIPTION
Some unit tests fail in `conda-build` because with empty `recipe_dir`/`dir` properties. The linter will then check the current directory for files, which can result in false positives.

# Changes

* Add checks for empty recipe directory names
* Remove hack for conda-build recipe for unit tests