### PR TITLE
Miscellaneous fixes

### DIFF
--- a/anaconda_linter/utils.py
+++ b/anaconda_linter/utils.py
@@ -263,9 +263,13 @@ def validate_config(config):
         directly.
     """
     if not isinstance(config, dict):
-        config = yaml.load(open(config))
+        with open(config) as c:
+            conf = c.read()
+        config = yaml.load(conf)
     fn = os.path.abspath(os.path.dirname(__file__)) + "/config.schema.yaml"
-    schema = yaml.load(open(fn))
+    with open(fn) as f:
+        schema_str = f.read()
+    schema = yaml.load(schema_str)
     validate(config, schema)
 
 
@@ -291,7 +295,8 @@ def load_config(path):
         def relpath(p):
             return os.path.join(os.path.dirname(path), p)
 
-        config = yaml.load(open(path))
+        with open(path) as conf:
+            config = yaml.load(conf.read())
 
     def get_list(key):
         # always return empty list, also if NoneType is defined in yaml

--- a/anaconda_linter/utils.py
+++ b/anaconda_linter/utils.py
@@ -263,13 +263,11 @@ def validate_config(config):
         directly.
     """
     if not isinstance(config, dict):
-        with open(config) as c:
-            conf = c.read()
-        config = yaml.load(conf)
+        with open(config) as conf:
+            config = yaml.load(conf.read())
     fn = os.path.abspath(os.path.dirname(__file__)) + "/config.schema.yaml"
     with open(fn) as f:
-        schema_str = f.read()
-    schema = yaml.load(schema_str)
+        schema = yaml.load(f.read())
     validate(config, schema)
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ test:
   commands:
     - pip check
     # lint_list is only an important test for development
-    - python -m pytest -vv tests -k 'not lint_list'
+    - python -m pytest -vv tests -k "not lint_list"
 
 about:
   home: https://github.com/anaconda-distribution/anaconda-linter

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -814,6 +814,20 @@ def test_pip_install_args_good_missing(base_yaml):
     assert len(messages) == 0
 
 
+def test_pip_install_args_good_missing_file(base_yaml, recipe_dir):
+    yaml_str = (
+        base_yaml
+        + """
+        requirements:
+          host:
+            - pip
+        """
+    )
+    lint_check = "pip_install_args"
+    messages = check_dir(lint_check, recipe_dir.parent, yaml_str)
+    assert len(messages) == 0
+
+
 def test_pip_install_args_good_cmd(base_yaml):
     yaml_str = (
         base_yaml

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -1488,6 +1488,22 @@ def test_missing_imports_or_run_test_py_good_imports(base_yaml):
     assert len(messages) == 0
 
 
+def test_missing_imports_or_run_test_py_good_pypi(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        test:
+          imports:
+            - module
+        """
+    )
+    lint_check = "missing_imports_or_run_test_py"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
 def test_missing_imports_or_run_test_py_good_script(base_yaml, recipe_dir):
     yaml_str = (
         base_yaml
@@ -1529,6 +1545,27 @@ def test_missing_imports_or_run_test_py_good_multi(base_yaml):
     assert len(messages) == 0
 
 
+def test_missing_imports_or_run_test_py_good_multi_pypi(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        outputs:
+          - name: output1
+            test:
+              imports:
+                - module1
+          - name: output2
+            test:
+              script: test_output2.py
+        """
+    )
+    lint_check = "missing_imports_or_run_test_py"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
 def test_missing_imports_or_run_test_py_bad(base_yaml):
     yaml_str = (
         base_yaml
@@ -1536,6 +1573,20 @@ def test_missing_imports_or_run_test_py_bad(base_yaml):
         requirements:
           host:
             - python
+        """
+    )
+    lint_check = "missing_imports_or_run_test_py"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 1 and "Python packages require imports" in messages[0].title
+
+
+def test_missing_imports_or_run_test_py_bad_pypi(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        test:
         """
     )
     lint_check = "missing_imports_or_run_test_py"
@@ -1556,6 +1607,26 @@ def test_missing_imports_or_run_test_py_bad_multi(base_yaml):
             requirements:
               host:
                 - python
+        """
+    )
+    lint_check = "missing_imports_or_run_test_py"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 2 and all(
+        "Python packages require imports" in msg.title for msg in messages
+    )
+
+
+def test_missing_imports_or_run_test_py_bad_multi_pypi(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        outputs:
+          - name: output1
+            test:
+          - name: output2
+            test:
         """
     )
     lint_check = "missing_imports_or_run_test_py"


### PR DESCRIPTION
This PR fixes a few issues that came up during building on different platforms.

* Load config files from strings instead of file handles. This riases `ruamel.yaml.reader.ReaderError` exceptions on s390x otherwise because of unacceptable characters.
* Change the recipe to use double quotes for pytest or Windows will look for file named `lint_list`
* Add missing unit tests to increase coverage