### PR TITLE
`pip` Dependency fix

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -4,6 +4,7 @@ dependencies:
   - python
   # build
   - setuptools
+  - pip
   # run
   - ruamel.yaml
   - license-expression


### PR DESCRIPTION
- Fixes `pip` dependency issue described in [ISSUE-209](https://github.com/anaconda-distribution/anaconda-linter/issues/209) during first-time setup.