### PR TITLE
Do not require version pin for hatch extensions

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -115,16 +115,16 @@ class host_section_needs_exact_pinnings(LintCheck):
 
     @staticmethod
     def is_exception(package):
-         exceptions = (
-             "python",
-             "toml",
-             "wheel",
-             *PYTHON_BUILD_TOOLS,
-         )
-         # It doesn't make sense to pin the versions of hatch plugins if we're not pinning
-         # hatch. We could explictly enumerate the 15 odd plugins in PYTHON_BUILD_TOOLS, but
-         # this seemed lower maintainance
-         return package in exceptions or re.match("^hatch-", package)
+        exceptions = (
+            "python",
+            "toml",
+            "wheel",
+            *PYTHON_BUILD_TOOLS,
+        )
+        # It doesn't make sense to pin the versions of hatch plugins if we're not pinning
+        # hatch. We could explictly enumerate the 15 odd plugins in PYTHON_BUILD_TOOLS, but
+        # this seemed lower maintainance
+        return (package in exceptions) or package.startswith("hatch-")
 
 
 class should_use_compilers(LintCheck):

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -38,7 +38,7 @@ def test_host_section_needs_exact_pinnings_good_multi(base_yaml):
     assert len(messages) == 0
 
 
-@pytest.mark.parametrize("package", ("python", "toml", "wheel", *PYTHON_BUILD_TOOLS))
+@pytest.mark.parametrize("package", ("python", "toml", "wheel", "hatch-vcs", *PYTHON_BUILD_TOOLS))
 def test_host_section_needs_exact_pinnings_good_exception(base_yaml, package):
     yaml_str = (
         base_yaml


### PR DESCRIPTION
Many recipies have hatch extensions such as hatch-vcs in their build stanza. It doesn't seem to make sense to exclude hatch from pins but require the extensions to pinned.

I chose to use a regex to exclude all packages with the 'hatch-' prefix. It might be overbroad, but proabaly is lower maintainance. An alternative implementation would be to add the known plugins to PYTHON_BUILD_TOOLS, at the cost of a periodic whack-a-mole expedition as new plugins are added.