### PR TITLE
Check for english specific doc links

### DIFF
--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -316,7 +316,7 @@ class documentation_overspecified(LintCheck):
 class documentation_specifies_language(LintCheck):
     """Use the generic link, not a language specific one
 
-    Please use PACKAGE.readthedocs.io not  PACKAGE.readthedocs.io/en/latest
+    Please use PACKAGE.readthedocs.io not PACKAGE.readthedocs.io/en/latest
 
     """
 

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -314,7 +314,7 @@ class documentation_overspecified(LintCheck):
 
 
 class documentation_specifies_language(LintCheck):
-    """Use the generic link not a language specific one
+    """Use the generic link, not a language specific one
 
     Please use PACKAGE.readthedocs.io not  PACKAGE.readthedocs.io/en/latest
 

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -312,6 +312,19 @@ class documentation_overspecified(LintCheck):
             self.message(section="about", severity=WARNING)
 
 
+class documentation_specifies_language(LintCheck):
+    """Use the generic link not a language specific one
+
+    Please use PACKAGE.readthedocs.io not  PACKAGE.readthedocs.io/en/latest
+
+    """
+
+    def check_recipe(self, recipe):
+        if recipe.get("about/doc_url", "") and recipe.get("about/doc_url", "").endswith("en/latest"):
+            self.message(section="about/doc_url")
+
+
+
 class missing_dev_url(LintCheck):
     """The recipe is missing a dev_url
 

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -4,6 +4,7 @@ Verify that the recipe is not missing anything essential.
 """
 
 import os
+import re
 
 import conda_build.license_family
 
@@ -320,9 +321,11 @@ class documentation_specifies_language(LintCheck):
     """
 
     def check_recipe(self, recipe):
-        if recipe.get("about/doc_url", "") and recipe.get("about/doc_url", "").endswith("en/latest"):
+        lang_url = re.compile(
+            r"readthedocs.io\/[a-z]{2,3}/latest"
+        )  # assume ISO639-1 or similar language code
+        if recipe.get("about/doc_url", "") and lang_url.search(recipe.get("about/doc_url", "")):
             self.message(section="about/doc_url")
-
 
 
 class missing_dev_url(LintCheck):

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -325,7 +325,7 @@ class documentation_specifies_language(LintCheck):
             r"readthedocs.io\/[a-z]{2,3}/latest"
         )  # assume ISO639-1 or similar language code
         if recipe.get("about/doc_url", "") and lang_url.search(recipe.get("about/doc_url", "")):
-            self.message(section="about/doc_url")
+            self.message(section="about/doc_url", severity=WARNING)
 
 
 class missing_dev_url(LintCheck):

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -12,6 +12,8 @@ cython_needs_compiler
 
 documentation_overspecified
 
+documentation_specifies_language
+
 duplicate_key_in_meta_yaml
 
 empty_meta_yaml

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -504,6 +504,19 @@ def test_documentation_specifies_language(base_yaml):
     )
 
 
+def test_documentation_does_not_specify_language(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        about:
+          doc_url: builder.readthedocs.io
+        """
+    )
+    lint_check = "documentation_specifies_language"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
 @pytest.mark.parametrize("doc_type", ("doc_url", "doc_source_url"))
 def test_documentation_overspecified_good(base_yaml, doc_type):
     yaml_str = (

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -488,6 +488,18 @@ def test_missing_documentation_bad(base_yaml):
     assert len(messages) == 1 and "doc_url or doc_source_url" in messages[0].title
 
 
+def test_documentation_specifies_language(base_yaml):
+    yaml_str = (
+        base_yaml
+        + f"""
+        about:
+          doc_url: builder.readthedocs.io/en/latest
+        """
+    )
+    lint_check = "documentation_specifies_language"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 1 and "Use the generic link not a language specific one" in messages[0].title
+
 @pytest.mark.parametrize("doc_type", ("doc_url", "doc_source_url"))
 def test_documentation_overspecified_good(base_yaml, doc_type):
     yaml_str = (

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -500,7 +500,7 @@ def test_documentation_specifies_language(base_yaml):
     messages = check(lint_check, yaml_str)
     assert (
         len(messages) == 1
-        and "Use the generic link not a language specific one" in messages[0].title
+        and "Use the generic link, not a language specific one" in messages[0].title
     )
 
 

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -491,7 +491,7 @@ def test_missing_documentation_bad(base_yaml):
 def test_documentation_specifies_language(base_yaml):
     yaml_str = (
         base_yaml
-        + f"""
+        + """
         about:
           doc_url: builder.readthedocs.io/en/latest
         """

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -498,7 +498,11 @@ def test_documentation_specifies_language(base_yaml):
     )
     lint_check = "documentation_specifies_language"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and "Use the generic link not a language specific one" in messages[0].title
+    assert (
+        len(messages) == 1
+        and "Use the generic link not a language specific one" in messages[0].title
+    )
+
 
 @pytest.mark.parametrize("doc_type", ("doc_url", "doc_source_url"))
 def test_documentation_overspecified_good(base_yaml, doc_type):


### PR DESCRIPTION
Check for english specific doc links
    
It is a common error to see links like "https://hatch-jupyter-builder.readthedocs.io/en/latest", which point to the English version of the docs, rather than the generic link which uses the browser language https://hatch-jupyter-builder.readthedocs.io.


