### PR TITLE
Prohibit license_family: None

### DIFF
--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -164,7 +164,7 @@ class invalid_license_family(LintCheck):
         if license_family:
             if license_family == "none":
                 msg = (
-                    " Using 'None' breaks some uploaders."
+                    " Using 'NONE' breaks some uploaders."
                     " Use skip-lint to skip this check instead."
                 )
                 self.message(msg, section="about")

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -150,7 +150,7 @@ class missing_license_family(LintCheck):
 
 
 class invalid_license_family(LintCheck):
-    """The recipe has an incorrect ``about/license_family`` value.
+    """The recipe has an incorrect ``about/license_family`` value.{}
 
     Please change::
 
@@ -160,10 +160,17 @@ class invalid_license_family(LintCheck):
     """
 
     def check_recipe(self, recipe):
-        license_family = recipe.get("about/license_family", "")
-        if license_family and not license_family.lower() in [
-            x.lower() for x in conda_build.license_family.allowed_license_families
-        ]:
+        license_family = recipe.get("about/license_family", "").lower()
+        if license_family:
+            if license_family == "none":
+                msg = (
+                    " Using 'None' breaks some uploaders."
+                    " Use skip-lint to skip this check instead."
+                )
+                self.message(
+            elif not license_family in [
+                x.lower() for x in conda_build.license_family.allowed_license_families
+            ]:
             self.message(section="about")
 
 

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -167,11 +167,11 @@ class invalid_license_family(LintCheck):
                     " Using 'None' breaks some uploaders."
                     " Use skip-lint to skip this check instead."
                 )
-                self.message(
-            elif not license_family in [
+                self.message(msg, section="about")
+            elif license_family not in [
                 x.lower() for x in conda_build.license_family.allowed_license_families
             ]:
-            self.message(section="about")
+                self.message(section="about")
 
 
 class missing_tests(LintCheck):

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -232,7 +232,11 @@ def test_invalid_license_family_none(base_yaml):
     )
     lint_check = "invalid_license_family"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and "about/license_family` value" in messages[0].title and "Using 'None' breaks" in messages[0].title
+    assert (
+        len(messages) == 1
+        and "about/license_family` value" in messages[0].title
+        and "Using 'None' breaks" in messages[0].title
+    )
 
 
 def test_missing_tests_good_import(base_yaml):

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -235,7 +235,7 @@ def test_invalid_license_family_none(base_yaml):
     assert (
         len(messages) == 1
         and "about/license_family` value" in messages[0].title
-        and "Using 'None' breaks" in messages[0].title
+        and "Using 'NONE' breaks" in messages[0].title
     )
 
 

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -222,6 +222,19 @@ def test_invalid_license_family(base_yaml):
     assert len(messages) == 1 and "about/license_family` value" in messages[0].title
 
 
+def test_invalid_license_family_none(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        about:
+          license_family: None
+        """
+    )
+    lint_check = "invalid_license_family"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 1 and "about/license_family` value" in messages[0].title and "Using 'None' breaks" in messages[0].title
+
+
 def test_missing_tests_good_import(base_yaml):
     yaml_str = (
         base_yaml


### PR DESCRIPTION
Using `"None"` as a value for `license_family` breaks some of our uploaders. Until this is fixed, the linter should prohibit the use of "None" as the license family.

# Changes:

* Check for license_family being `"None"`.
* Add explanation to the lint message.
* Add unit test for this special case.