### PR TITLE
Remove "packaging" package from PYTHON_BUILD_TOOLS

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -36,7 +36,6 @@ PYTHON_BUILD_TOOLS = (
     "hatchling",
     "meson",
     "meson-python",
-    "packaging",
     "pdm",
     "pdm-pep517",
     "pip",


### PR DESCRIPTION
Remove "packaging" package from `PYTHON_BUILD_TOOLS` list since it's no…t a build tool.

`packaging` is a library, not a tool and some packages do use it at runtime. These packages are valid because `packaging` contains utilities to parse versions, requirements, build tags, etc, which they sometimes need.