### PR TITLE
Fix linter parsing bugs

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -456,7 +456,7 @@ class avoid_noarch(LintCheck):
         noarch = recipe.get("build/noarch", "")
         if (
             noarch == "python"
-            and recipe.get("build/number", 0) == 0
+            and int(recipe.get("build/number", 0)) == 0
             and not recipe.get("build/osx_is_app", False)
             and not recipe.get("app", None)
         ):

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -552,7 +552,11 @@ class missing_imports_or_run_test_py(LintCheck):
             if is_pypi:
                 paths_to_check = [f"outputs/{o}" for o in range(len(outputs))]
             else:
-                paths_to_check = ["/".join(path.split("/")[:2]) for path in deps["python"]["paths"]]
+                paths_to_check = [
+                    "/".join(path.split("/")[:2])
+                    for path in deps["python"]["paths"]
+                    if not path.startswith("requirements")
+                ]
             for path in paths_to_check:
                 if not recipe.get(f"{path}/test/imports", []) and not recipe.get(
                     f"{path}/test/script", ""


### PR DESCRIPTION
This PR fixes two bugs that parse/interpret the recipe badly.

# Changes

* Convert the build number into int. This does not appear to be done consistently by the YAML parser.
* Do not check the `requirements` field in `missing_imports_or_run_test_py` for multi-output recipes.