### PR TITLE
percy 0.0.5 with patch support

### DIFF
--- a/anaconda_linter/data/cbc_default.yaml
+++ b/anaconda_linter/data/cbc_default.yaml
@@ -25,7 +25,7 @@ osx-64: 0
 osx-arm64: 0
 arm64: 0
 
-py: 39
+py: 310
 py3k: 1
 py2k: 0
 py26: 0
@@ -36,10 +36,10 @@ py35: 0
 py36: 0
 py37: 0
 py38: 0
-py39: 1
-py310: 0
+py39: 0
+py310: 1
 py311: 0
-numpy: "1.16"
-nunpy: "1.16"
+numpy: "1.21"
+nunpy: "1.21"
 np: "1.16"
 pl: "5.26"

--- a/anaconda_linter/data/conda_build_config.yaml
+++ b/anaconda_linter/data/conda_build_config.yaml
@@ -1,12 +1,12 @@
-myval1: "value"
+# copied from https://github.com/AnacondaRecipes/aggregate/commit/155179deb78b587ba0bcdda4e7f45bc6e18e9071
 
 pin_run_as_build:
   libboost:
     max_pin: x.x.x
-noarch_python:
-  - python
+
 apr:
-  - 1.6.3
+  - 1.6.3  # [not (osx and arm64)]
+  - 1.7.0  # [osx and arm64]
 blas_impl:
   - mkl                        # [x86 or x86_64]
   - openblas                   # [not win]
@@ -17,32 +17,18 @@ boost_cpp:
 bzip2:
   - 1.0
 cairo:
-  - 1.14                       # [not s390x]
-  - 1.16                       # [s390x]
+  - 1.16
 c_compiler:
+  - gcc                        # [linux]
   - clang                      # [osx]
   - vs2017                     # [win]
-  - vs2017                     # [win]
-  - vs2017                     # [win]
-  - vs2017                     # [win]
 cxx_compiler:
+  - gxx                        # [linux]
   - clangxx                    # [osx]
   - vs2017                     # [win]
-  - vs2017                     # [win]
-  - vs2017                     # [win]
-  - vs2017                     # [win]
 fortran_compiler:
+  - gfortran                   # [linux or osx]
   - intel-fortran              # [win]
-fortran_compiler_version:
-  - 2019.0.0                     # [win]
-  - 2019.0.0                     # [win]
-  - 2019.0.0                     # [win]
-  - 2019.0.0                     # [win]
-# matrix on linux, because the ABI breaks at GCC 8
-  - 7.3.0                      # [linux and not s390x]
-  - 8.2.0                      # [linux and not s390x]
-  - 7.5.0                      # [linux and s390x]
-  - 8.4.0                      # [linux and s390x]
 m2w64_c_compiler:              # [win]
   - m2w64-toolchain            # [win]
 m2w64_cxx_compiler:            # [win]
@@ -53,9 +39,10 @@ rust_compiler:
   - rust
   - rust-gnu                   # [win]
 rust_compiler_version:
-  - 1.46.0
+  - 1.64.0
 CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.10.sdk        # [osx]
+  - /opt/MacOSX10.10.sdk        # [osx and x86_64]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx and arm64]
 VERBOSE_AT:
   - V=1
 VERBOSE_CM:
@@ -64,71 +51,70 @@ VERBOSE_CM:
 cran_mirror:
   - https://mran.microsoft.com/snapshot/2018-01-01
 c_compiler_version:        # [linux or osx]
-  - 7.3.0                  # [linux and not s390x]
-  - 7.5.0                  # [linux and s390x]
-  - 10                     # [osx]
+  - 11.2.0                 # [linux]
+  - 14                     # [osx]
 cxx_compiler_version:      # [linux or osx]
-  - 7.3.0                  # [linux and not s390x]
-  - 7.5.0                  # [linux and s390x]
-  - 10                     # [osx]
-fortran_compiler_version:  # [linux]
-  - 7.3.0                  # [linux and not s390x]
-  - 7.5.0                  # [linux and s390x]
+  - 11.2.0                 # [linux]
+  - 14                     # [osx]
+fortran_compiler_version:
+  - 2022.1.0                     # [win]
+  - 11.2.0                       # [osx or linux]
 clang_variant:
   - clang
 cyrus_sasl:
-  - 2.1.26
+  - 2.1.26  # [not ((osx and arm64) or (linux and aarch64))]
+  - 2.1.27  # [(osx and arm64) or (linux and aarch64)]
 dbus:
   - 1
 expat:
-  - 2.2
+  - 2
 fontconfig:
-  - 2.13
+  - 2.14
 freetype:
   - 2.10
 g2clib:
   - 1.6
 gstreamer:
-  - 1.14
+  - 1.14  # [not win]
+  - 1.18  # [win]
 gst_plugins_base:
-  - 1.14
+  - 1.14  # [not win]
+  - 1.18  # [win]
 geos:
-  - 3.8.0  # [win]
-  - 3.8.0  # [win]
-  - 3.8.0  # [win]
-  - 3.8.0
+  - 3.8.0  # [not (osx and arm64)]
+  - 3.9.1  # [osx and arm64]
 giflib:
   - 5
 glib:
   - 2
 gmp:
-  - 6.1
+  - 6.1  # [not (osx and arm64)]
+  - 6.2  # [osx and arm64]
 # glibc used in ctng compiler builds
 gnu:
   - 2.12.2
 harfbuzz:
-  - 2.4
+  - 4.3.0
 hdf4:
   - 4.2
 hdf5:
-  - 1.10.6
+  - 1.10.6  # [not (osx and arm64)]
+  - 1.12.1  # [osx and arm64]
 hdfeos2:
   - 2.20
 hdfeos5:
   - 5.1
 icu:
-  - 58  # [not s390x]
-  - 68  # [s390x]
+  - 58  # [not (s390x or aarch64 or (osx and arm64))]
+  - 68  # [s390x or aarch64 or (osx and arm64)]
 jpeg:
   - 9
 libdap4:
   - 3.19
 libffi:
-  - 3.3  # [not win]
-  # Patches need to be rebased
-  - 3.2.1  # [win]
+  - 3.4
 libgd:
-  - 2.2.5
+  - 2.3.3
 libgdal:
   - 3.0
 libgsasl:
@@ -136,16 +122,16 @@ libgsasl:
 libkml:
   - 1.3
 libnetcdf:
-  - 4.6
+  - 4.8
 libpng:
   - 1.6
 libtiff:
-  - 4.1
+  - 4.1  # [not ((osx and arm64) or (linux and aarch64))]
+  - 4.2  # [(osx and arm64) or (linux and aarch64)]
 libwebp:
-  - 1.0.0   # [not s390x]
-  - 1.2.0   # [s390x]
+  - 1.2.4
 libxml2:
-  - 2.9
+  - 2.10
 libxslt:
   - 1.1
 llvm_variant:
@@ -153,44 +139,52 @@ llvm_variant:
 lzo:
   - 2
 macos_min_version:
-  - 10.9
+  - 10.9  # [osx and x86_64]
+  - 11.1  # [osx and arm64]
 macos_machine:
-  - x86_64-apple-darwin13.4.0
+  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
+  - arm64-apple-darwin20.0.0   # [osx and arm64]
 MACOSX_DEPLOYMENT_TARGET:
-  - 10.9
+  - 10.9  # [osx and x86_64]
+  - 11.1  # [osx and arm64]
 mkl:
-  - 2019
+  - 2023.*
 mpfr:
   - 4
 # we build for an old version of numpy for forward compatibility
 numpy:
-  - 1.16
+  # python 3.8
+  - 1.21
+  # python 3.9
+  - 1.21
+  # python 3.10
+  - 1.21
+  # python 3.11
+  - 1.23
 openblas:
-  - 0.3.3   # [not s390x]
-  - 0.3.10  # [s390x]
+  - 0.3.21
 openjpeg:
   - 2.3
 openssl:
   - 1.1.1
-  # vs2008 precludes us from newer qt, and we haven't been able to build newer qt with openssl 1.1.1 yet
-  - 1.0.2   # [win and py27]
+  - 3.0
 perl:
-  - 5.26
+  - 5.26    # [win]
+  - 5.34    # [not win]
 pixman:
-  - 0.30      # [not s390x]
-  - 0.40      # [s390x]
+  - 0.40
 proj4:
   - 5.2.0
 proj:
-  - 6.2.1
+  - 6.2.1  # [not (osx and arm64)]
+  - 7.2.0  # [osx and arm64]
 libprotobuf:
-  - 3.11.2    # [not s390x]
-  - 3.14.0    # [s390x]
+  - 3.20.3
 python:
-  - 3.6      # [not s390x]
-  - 3.7
   - 3.8
   - 3.9
+  - "3.10"
+  - "3.11"
 python_implementation:
   - cpython
 python_impl:
@@ -201,7 +195,8 @@ r_implementation:
   - 'r-base'
   - 'mro-base'  # [not osx]
 readline:
-  - 8.0
+  - 8.0    # [not ((linux and aarch64) or (osx and arm64))]
+  - 8.1    # [(linux and aarch64) or (osx and arm64)]
 serf:
   - 1.3.9
 sqlite:
@@ -211,31 +206,26 @@ sqlite:
 #    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
 #    code on win-64 miniconda.
 cross_compiler_target_platform:
-  - win-32                     # [win]
+  # - win-32                     # [win]
   - win-64                     # [win]
 target_platform:
   - win-64                     # [win]
-  - win-32                     # [win]
+  # - win-32                     # [win]
 tk:
-  - 8.6                # [not ppc64le]
+  - 8.6
 vc:
-  - 14                         # [win]
-  - 14                         # [win]
-  - 14                         # [win]
   - 14                         # [win]
 zlib:
   - 1.2
 xz:
   - 5
-qtwebkit:
-  - true
 channel_targets:
   - defaults
+cdt_name:
+  - amzn2    # [linux and aarch64]
 zip_keys:
-  -                             # [win]
-    - vc                        # [win]
-    - c_compiler                # [win]
-    - cxx_compiler              # [win]
-    - fortran_compiler_version  # [win]
-    - python                    # [win]
-    - geos                      # [win]
+  -
+    - python
+    - numpy
+zstd:
+  - 1.5.2

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -696,10 +696,10 @@ class Linter:
                     exclusive_config_files=exclusive_config_files,
                 )
             else:
-                logging.warning(
+                logging.debug(
                     "No cbc in current path. Loading copy of aggregate cbc embedded in linter."
                 )
-                logging.warning("Please run from your aggregate dir for better results.")
+                logging.debug("Please run from your aggregate dir for better results.")
                 local_cbc = Path(__file__).parent.parent / "data" / "conda_build_config.yaml"
                 var_config_files = variant_config_files
                 var_config_files.append(str(local_cbc))
@@ -725,15 +725,16 @@ class Linter:
                     variant=variant,
                     renderer=RendererType.RUAMEL,
                 )
-                messages.update(
-                    self.lint_recipe(
-                        recipe,
-                        fix=fix,
+                if not recipe.skip:
+                    messages.update(
+                        self.lint_recipe(
+                            recipe,
+                            fix=fix,
+                        )
                     )
-                )
-                if fix and recipe.is_modified():
-                    with open(recipe.path, "w", encoding="utf-8") as fdes:
-                        fdes.write(recipe.dump())
+                    if fix and recipe.is_modified():
+                        with open(recipe.path, "w", encoding="utf-8") as fdes:
+                            fdes.write(recipe.dump())
         except RecipeError as exc:
             recipe = _recipe.Recipe(recipe_name)
             check_cls = recipe_error_to_lint_check.get(exc.__class__, linter_failure)

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -92,6 +92,12 @@ from typing import Any, Dict, List, NamedTuple, Tuple
 
 import networkx as nx
 import percy.render.recipe as _recipe
+from percy.render.exceptions import (
+    EmptyRecipe,
+    JinjaRenderFailure,
+    MissingMetaYaml,
+    YAMLRenderFailure,
+)
 from percy.render.recipe import RendererType
 from percy.render.variants import read_conda_build_config
 
@@ -496,10 +502,10 @@ class unknown_check(LintCheck):
 
 #: Maps `_recipe.RecipeError` to `LintCheck`
 recipe_error_to_lint_check = {
-    _recipe.EmptyRecipe: empty_meta_yaml,
-    _recipe.MissingMetaYaml: missing_meta_yaml,
-    _recipe.JinjaRenderFailure: jinja_render_failure,
-    _recipe.YAMLRenderFailure: yaml_load_failure,
+    EmptyRecipe: empty_meta_yaml,
+    MissingMetaYaml: missing_meta_yaml,
+    JinjaRenderFailure: jinja_render_failure,
+    YAMLRenderFailure: yaml_load_failure,
 }
 
 

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -468,7 +468,7 @@ class avoid_noarch(LintCheck):
 
     def fix(self, _message, _data):
         (recipe, package) = _data
-        skip_selector = " # [py<38]"
+        skip_selector = None
         for dep in recipe.get(f"{package.path_prefix}requirements/run", []):
             if dep.startswith("python"):
                 s = dep.split(">=")
@@ -477,7 +477,6 @@ class avoid_noarch(LintCheck):
                 break
         op = [
             {"op": "remove", "path": "@output/build/noarch"},
-            {"op": "add", "path": "@output/build/skip", "value": f"True {skip_selector}"},
             {
                 "op": "add",
                 "path": "@output/requirements/host",
@@ -497,6 +496,8 @@ class avoid_noarch(LintCheck):
                 "value": ["python"],
             },
         ]
+        if skip_selector:
+            op.append({"op": "add", "path": "@output/build/skip", "value": f"True {skip_selector}"})
         recipe.patch(op)
         return True
 

--- a/anaconda_linter/run.py
+++ b/anaconda_linter/run.py
@@ -82,6 +82,13 @@ def lint_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Enable verbose output. This displays all of the checks that the linter is running.",
     )
+    # this is here because we have a different default than build
+    parser.add_argument(
+        "-f",
+        "--fix",
+        action="store_true",
+        help="Attempt to fix issues.",
+    )
     return parser
 
 
@@ -105,7 +112,7 @@ def main():
     overall_result = 0
     for subdir in args.subdirs:
         result = linter.lint(
-            recipes, subdir, args.variant_config_files, args.exclusive_config_files
+            recipes, subdir, args.variant_config_files, args.exclusive_config_files, args.fix
         )
         if result > overall_result:
             overall_result = result

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,7 +8,7 @@ dependencies:
   - setuptools
   - pip
   # run
-  - percy ==0.0.4
+  - percy ==0.0.5
   - ruamel.yaml
   - license-expression
   - jinja2

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,7 +8,7 @@ dependencies:
   - setuptools
   - pip
   # run
-  - percy ==0.0.3
+  - percy ==0.0.4
   - ruamel.yaml
   - license-expression
   - jinja2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - conda-build
     - jsonschema
     - networkx
-    - percy ==0.0.3
+    - percy ==0.0.4
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - conda-build
     - jsonschema
     - networkx
-    - percy ==0.0.4
+    - percy ==0.0.5
 
 test:
   source_files:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ def main():
         "networkx",
         "requests",
         "ruamel.yaml",
-        "percy==0.0.4",
     ]
     test_requirements = ["pytest", "pytest-cov", "pytest-html"]
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def main():
         "networkx",
         "requests",
         "ruamel.yaml",
-        "percy==0.0.3",
+        "percy==0.0.4",
     ]
     test_requirements = ["pytest", "pytest-cov", "pytest-html"]
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 import pytest
 from conftest import check, check_dir
-from percy.render.recipe import Recipe, RecipeError, RendererType
+from percy.render.exceptions import RecipeError
+from percy.render.recipe import Recipe, RendererType
 
 from anaconda_linter import lint, utils
 from anaconda_linter.lint import ERROR, INFO, WARNING


### PR DESCRIPTION
Changes:
- Update percy to 0.0.5 (few bug fixes, recipe patch support)
- When not run from aggregate, use a conda_build_config.yaml copy as configuration to identify variants
- Run linter on all rendered variants
- Add --fix option to linter
- Implement fix for missing_wheel, pip_install_args, avoid_noarch, missing_pip_check, missing_test_requirement_pip, missing_python, remove_python_pinning

I don't have code testing the fix methods at this point.
As a test you can run generate a recipe with grayskull and call conda-lint with --fix.
