### PR TITLE
Add knowledge of Python build backends to the missing_wheel rule

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -50,6 +50,25 @@ PYTHON_BUILD_TOOLS = (
     "whey",
 )
 
+# List of known PEP-517 backends (https://peps.python.org/pep-0517/) that are not setuptools
+# and that don't require wheel since they create wheels themselves.
+# The backend is defined using the pyproject.toml file (which was intruduced by PEP-518).
+# Historical note: pyproject.toml file was introduced initially to specify the build system (backend).
+# Only later was the ability to specify all the project metadata (name, version, dependencies, etc)
+# into it added, via PEP-621.
+PYTHON_BUILD_BACKENDS = (
+    "flit",  # Our packages are not supposed to depend on flit, but apparently they do, so we need to support it here.
+    "flit-core",  # Backend of flit.
+    "hatch",  # Same as flit, we should not depende on it. We should instead depend on hatchling, which is the backend.
+    "hatchling",  # Backend of hatch.
+    "meson-python",  # Backend that uses meson.
+    "pdm-backend",  # Backend of pdm (new). Not yet in our repo, but if it ever does, we'll be able to handle it.
+    "pdm-pep517",  # Deprecated backend of pdm but we still need to support it, see https://pypi.org/project/pdm-pep517
+    "poetry-core",  # Backend of poetry.
+    "scikit-build-core",  # Backend that uses cmake.
+    "whey",
+)
+
 COMPILERS = (
     "cgo",
     "cuda",
@@ -264,13 +283,25 @@ class missing_wheel(LintCheck):
 
     def check_recipe(self, recipe):
         is_pypi = is_pypi_source(recipe)
+
         for package in recipe.packages.values():
             if (
                 is_pypi
                 or recipe.contains(f"{package.path_prefix}build/script", "pip install", "")
                 or recipe.contains(f"{package.path_prefix}script", "pip install", "")
             ):
-                if not package.has_dep("host", "wheel"):
+                # Note that we do the assumption that if none of the backends defined in exceptions are present
+                # and that setuptools is also not present, that setuptools will be used via the good old
+                # setup.py file. This is because pip defaults to doing that for historical reasons.
+                # This means that if pip is used in the install script and there is no host dependencies,
+                # we want this check to raise a warning because wheel should be added there!
+                #
+                # In theory we would also need to warn if setuptools missing in the host
+                # section and none of the new build backends are used.
+                # TODO: add a missing_setuptools rule?
+                if not package.has_dep("host", "wheel") and not set(
+                    PYTHON_BUILD_BACKENDS
+                ).intersection({dep.pkg.lower() for dep in package.get("host")}):
                     self.message(
                         section=f"{package.path_prefix}requirements/host",
                         data=(recipe, package),

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -59,7 +59,7 @@ PYTHON_BUILD_TOOLS = (
 PYTHON_BUILD_BACKENDS = (
     "flit",  # Our packages are not supposed to depend on flit, but apparently they do, so we need to support it here.
     "flit-core",  # Backend of flit.
-    "hatch",  # Same as flit, we should not depende on it. We should instead depend on hatchling, which is the backend.
+    "hatch",  # Same as flit, we should not depend on it. We should instead depend on hatchling, which is the backend.
     "hatchling",  # Backend of hatch.
     "meson-python",  # Backend that uses meson.
     "pdm-backend",  # Backend of pdm (new). Not yet in our repo, but if it ever does, we'll be able to handle it.

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -1,7 +1,12 @@
 import pytest
 from conftest import check, check_dir
 
-from anaconda_linter.lint.check_build_help import BUILD_TOOLS, COMPILERS, PYTHON_BUILD_TOOLS
+from anaconda_linter.lint.check_build_help import (
+    BUILD_TOOLS,
+    COMPILERS,
+    PYTHON_BUILD_BACKENDS,
+    PYTHON_BUILD_TOOLS,
+)
 
 
 def test_host_section_needs_exact_pinnings_good(base_yaml):
@@ -711,6 +716,23 @@ def test_missing_wheel_url_good(base_yaml):
     assert len(messages) == 0
 
 
+@pytest.mark.parametrize("build_backend", PYTHON_BUILD_BACKENDS)
+def test_missing_wheel_url_good_alt_backend(base_yaml, build_backend):
+    yaml_str = (
+        base_yaml
+        + f"""
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        requirements:
+          host:
+            - {build_backend}
+        """
+    )
+    lint_check = "missing_wheel"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
 def test_missing_wheel_url_bad(base_yaml):
     yaml_str = (
         base_yaml
@@ -776,6 +798,29 @@ def test_missing_wheel_pip_install_good_multi(base_yaml):
             requirements:
               host:
                 - wheel
+        """
+    )
+    lint_check = "missing_wheel"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+@pytest.mark.parametrize("build_backend", PYTHON_BUILD_BACKENDS)
+def test_missing_wheel_pip_install_good_multi_alt_backend(base_yaml, build_backend):
+    yaml_str = (
+        base_yaml
+        + f"""
+        outputs:
+          - name: output1
+            script: {{{{ PYTHON }}}} -m pip install .
+            requirements:
+              host:
+                - {build_backend}
+          - name: output2
+            script: {{{{ PYTHON }}}} -m pip install .
+            requirements:
+              host:
+                - {build_backend}
         """
     )
     lint_check = "missing_wheel"


### PR DESCRIPTION
Add knowledge of Python build backends to the missing_wheel rule so that it doesn't warn when other backends than setuptools is used.

In other words, the `missing_wheel` rule should only apply if no known Python [PEP-517](https://peps.python.org/pep-0517/) build backend is detected in the `host` dependencies.