### PR TITLE
Adds support for `no_git_on_windows` auto-fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 #   pre-commit run --all-files
 # Update this file:
 #   pre-commit autoupdate
+exclude: tests/test_aux_files/.*
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ pre-commit:        ## Runs pre-commit against files
 test:              ## Run tests
 	mkdir -p $(ARTIFACTS_PATH)
 	python -m pytest \
+		-n auto \
 		--junit-xml="$(ARTIFACTS_PATH)/test-report.xml" \
 		--html="$(ARTIFACTS_PATH)/test-report.html" \
 		--cov \

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -565,7 +565,7 @@ class Linter:
             self.checks_ordered = reversed(list(nx.topological_sort(dag)))
         except nx.NetworkXUnfeasible:
             raise RuntimeError("Cycle in LintCheck requirements!")
-        self.check_instances = {str(check): check(self) for check in get_checks()}
+        self.check_instances: dict[str, LintCheck] = {str(check): check(self) for check in get_checks()}
 
     def get_messages(self) -> List[LintMessage]:
         """Returns the lint messages collected during linting"""

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -565,7 +565,9 @@ class Linter:
             self.checks_ordered = reversed(list(nx.topological_sort(dag)))
         except nx.NetworkXUnfeasible:
             raise RuntimeError("Cycle in LintCheck requirements!")
-        self.check_instances: dict[str, LintCheck] = {str(check): check(self) for check in get_checks()}
+        self.check_instances: dict[str, LintCheck] = {
+            str(check): check(self) for check in get_checks()
+        }
 
     def get_messages(self) -> List[LintMessage]:
         """Returns the lint messages collected during linting"""

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -10,6 +10,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from percy.parser.recipe_parser import RecipeParser, SelectorConflictMode
+
 from .. import utils as _utils
 from . import INFO, WARNING, LintCheck
 
@@ -982,7 +984,21 @@ class no_git_on_windows(LintCheck):
         if self.recipe.selector_dict.get("win", 0) == 1 and "git" in deps:
             for path in deps["git"]["paths"]:
                 output = -1 if not path.startswith("outputs") else int(path.split("/")[1])
-                self.message(section=path, output=output)
+                self.message(section=path, output=output, data=path)
+
+    def fix(self, _message, _data) -> bool:
+        # NOTE: The path found in `check_deps()` is a post-selector-rendering
+        # path to the dependency. So in order to change the recipe file, we need
+        # to relocate `git`, relative to the raw file.
+        def _add_git_selector(parser: RecipeParser) -> None:
+            paths = parser.find_value("git")
+            for path in paths:
+                # Attempt to filter-out false-positives
+                if not path.startswith("/requirements/"):
+                    continue
+                parser.add_selector(path, "[not win]", SelectorConflictMode.AND)
+
+        return self.recipe.patch_with_parser(_add_git_selector)
 
 
 class gui_app(LintCheck):

--- a/environment.yaml
+++ b/environment.yaml
@@ -23,3 +23,4 @@ dependencies:
   # plug ins
   - pytest-cov
   - pytest-html
+  - pytest-xdist

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Final, Optional, Union
+from unittest.mock import mock_open, patch
 
 import pytest
 from percy.render.recipe import Recipe, RendererType
@@ -9,8 +10,6 @@ from percy.render.variants import Variant, read_conda_build_config
 
 from anaconda_linter import utils
 from anaconda_linter.lint import Linter, LintMessage
-
-from unittest.mock import mock_open, patch
 
 # Locations of test files
 TEST_FILES_PATH: Final[str] = "tests/test_aux_files"
@@ -50,11 +49,13 @@ def load_file(file: Path | str) -> str:
     :param file:    Filename of the file to read
     :return: Text from the file
     """
-    with open(Path(file), "r", encoding="utf-8") as f:
+    with open(Path(file), encoding="utf-8") as f:
         return f.read()
 
 
-def load_linter_and_recipe(recipe_str: str, arch: str="linux-64", expand_variant: Optional[Variant]=None) -> tuple[Linter, Recipe]:
+def load_linter_and_recipe(
+    recipe_str: str, arch: str = "linux-64", expand_variant: Optional[Variant] = None
+) -> tuple[Linter, Recipe]:
     """
     Convenience function that loads instantiates linter and recipe objects based on default configurations.
     :param recipe_str:      Recipe file, as a raw string
@@ -77,13 +78,20 @@ def load_linter_and_recipe(recipe_str: str, arch: str="linux-64", expand_variant
     return linter, recipe
 
 
-def check(check_name: str, recipe_str: str, arch: str="linux-64", expand_variant: Optional[Variant]=None) -> list[LintMessage]:
+def check(
+    check_name: str,
+    recipe_str: str,
+    arch: str = "linux-64",
+    expand_variant: Optional[Variant] = None,
+) -> list[LintMessage]:
     linter, recipe = load_linter_and_recipe(recipe_str, arch, expand_variant)
     messages = linter.check_instances[check_name].run(recipe=recipe)
     return messages
 
 
-def check_dir(check_name: str, feedstock_dir: Union[str, Path], recipe_str: str, arch: str="linux-64") -> list[LintMessage]:
+def check_dir(
+    check_name: str, feedstock_dir: Union[str, Path], recipe_str: str, arch: str = "linux-64"
+) -> list[LintMessage]:
     if not isinstance(feedstock_dir, Path):
         feedstock_dir = Path(feedstock_dir)
     config_file = Path(__file__).parent / "config.yaml"
@@ -106,6 +114,7 @@ def check_dir(check_name: str, feedstock_dir: Union[str, Path], recipe_str: str,
     )
     messages = linter.check_instances[check_name].run(recipe=recipe)
     return messages
+
 
 def assert_on_auto_fix(check_name: str, arch="linux-64") -> None:
     """

--- a/tests/test_aux_files/auto_fix/no_git_on_windows.yaml
+++ b/tests/test_aux_files/auto_fix/no_git_on_windows.yaml
@@ -1,0 +1,64 @@
+{% set name = "fastparquet" %}
+{% set version = "2023.8.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/f/{{ name }}/{{ name }}-{{ version  }}.tar.gz
+  sha256: 2ff39bc20869829ea8fd85bf0336c5006d0ffcc276d0de070030cf8ffd929160
+
+build:
+  number: 0
+  #skip s390x because of lack of cramjam and numba
+  skip: true  # [py<38 or s390x]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - git
+  host:
+    - python
+    - pip
+    - wheel
+    - setuptools
+    - numpy {{ numpy }}
+    - cython 0.29
+    - pytest-runner
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - pandas >=1.5.0
+    - cramjam >=2.3.0
+    - fsspec
+    - packaging
+
+test:
+  imports:
+    - fastparquet
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/dask/fastparquet
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: Python interface to the parquet format
+  description: |
+    The fastparquet is a python implementation of the parquet format, aiming integrate into python-based big data work-flows.
+    It is used implicitly by the projects Dask, Pandas and intake-parquet.
+    The Parquet format is a common binary data store, used particularly in the Hadoop/big-data sphere.
+    It provides several advantages relevant to big-data processing.
+  dev_url: https://github.com/dask/fastparquet
+  doc_url: https://fastparquet.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - martindurant
+    - mrocklin
+    - TomAugspurger

--- a/tests/test_aux_files/auto_fix/no_git_on_windows_fixed.yaml
+++ b/tests/test_aux_files/auto_fix/no_git_on_windows_fixed.yaml
@@ -1,0 +1,64 @@
+{% set name = "fastparquet" %}
+{% set version = "2023.8.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/f/{{ name }}/{{ name }}-{{ version  }}.tar.gz
+  sha256: 2ff39bc20869829ea8fd85bf0336c5006d0ffcc276d0de070030cf8ffd929160
+
+build:
+  number: 0
+  #skip s390x because of lack of cramjam and numba
+  skip: true  # [py<38 or s390x]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - git  # [not win]
+  host:
+    - python
+    - pip
+    - wheel
+    - setuptools
+    - numpy {{ numpy }}
+    - cython 0.29
+    - pytest-runner
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - pandas >=1.5.0
+    - cramjam >=2.3.0
+    - fsspec
+    - packaging
+
+test:
+  imports:
+    - fastparquet
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/dask/fastparquet
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: Python interface to the parquet format
+  description: |
+    The fastparquet is a python implementation of the parquet format, aiming integrate into python-based big data work-flows.
+    It is used implicitly by the projects Dask, Pandas and intake-parquet.
+    The Parquet format is a common binary data store, used particularly in the Hadoop/big-data sphere.
+    It provides several advantages relevant to big-data processing.
+  dev_url: https://github.com/dask/fastparquet
+  doc_url: https://fastparquet.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - martindurant
+    - mrocklin
+    - TomAugspurger

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import pytest
-from conftest import check, check_dir
+from conftest import check, check_dir, assert_on_auto_fix
 
 from anaconda_linter.lint.check_build_help import (
     BUILD_TOOLS,
@@ -2952,6 +2954,12 @@ def test_no_git_on_windows_bad_multi(base_yaml):
     lint_check = "no_git_on_windows"
     messages = check(lint_check, yaml_str, arch="win-64")
     assert len(messages) == 2 and all("git should not be used" in msg.title for msg in messages)
+
+def test_no_git_on_windows_auto_fix() -> None:
+    """
+    Tests the auto-fix functionality of the `no_git_on_windows` rule.
+    """
+    assert_on_auto_fix("no_git_on_windows", "win-64")
 
 
 def test_gui_app_good(base_yaml):

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pytest
-from conftest import check, check_dir, assert_on_auto_fix
+from conftest import assert_on_auto_fix, check, check_dir
 
 from anaconda_linter.lint.check_build_help import (
     BUILD_TOOLS,
@@ -2954,6 +2954,7 @@ def test_no_git_on_windows_bad_multi(base_yaml):
     lint_check = "no_git_on_windows"
     messages = check(lint_check, yaml_str, arch="win-64")
     assert len(messages) == 2 and all("git should not be used" in msg.title for msg in messages)
+
 
 def test_no_git_on_windows_auto_fix() -> None:
     """


### PR DESCRIPTION
Adds support for auto fixing the `no-git-on-windows` rule using the new parse tree tooling in `percy`.

NOTE: This requires changes found in [this percy PR](https://github.com/anaconda-distribution/percy/pull/63) so DO NOT MERGE, until that is merged AND available to the linter.

This PR is being put up as a proof of concept, to show that the new parse tree work can be integrated into Anaconda Linter.

`percy` will need a new version bump AND the linter will need to pin to that new version of `percy` prior to accepting this PR.

This was tested manually using a local dev copy of `percy`. I can add a unit test in a subsequent commit. Again, this is mostly going out prematurely as a POC.