### PR TITLE
0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
 - Add auto-fix for cbc_dep_in_run_missing_from_host, uses_setup_py, pip_install_args
 - Update percy to >=0.1.0,<0.2.0
 - Add wrong_output_script_key
+- Add potentially_bad_ignore_run_exports
 
 ## 0.1.0
 - Use percy as render backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
 - Make uses_setup_py an error
 - Add auto-fix for cbc_dep_in_run_missing_from_host, uses_setup_py, pip_install_args
 - Update percy to >=0.1.0,<0.2.0
+- Add wrong_output_script_key
 
 ## 0.1.0
 - Use percy as render backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 Note: version releases in the 0.x.y range may introduce breaking changes.
 
 ## 0.1.1
-
+- Add knowledge of Python build backends to the missing_wheel rule
+- Relax host_section_needs_exact_pinnings
+- Add cbc_dep_in_run_missing_from_host
+- Make uses_setup_py an error
+- Add auto-fix for cbc_dep_in_run_missing_from_host, uses_setup_py, pip_install_args
+- Update percy to >=0.1.0,<0.2.0
 
 ## 0.1.0
 - Use percy as render backend

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -27,7 +27,7 @@ Briefly, each class becomes a check by:
 - The class property ``requires`` may contain a list of other check
   classes that are required to have passed before this check is
   executed. Use this to avoid duplicate errors presented, or to
-  ensure that asumptions made by your check are met by the recipe.
+  ensure that assumptions made by your check are met by the recipe.
 
 - Each class is instantiated once per linting run. Do slow preparation
   work in the constructor. E.g. the `recipe_in_blocklist` check

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -370,20 +370,25 @@ class uses_setup_py(LintCheck):
     """
 
     @staticmethod
-    def _check_line(line: str) -> bool:
+    def _check_line(x: str) -> bool:
         """Check a line for a broken call to setup.py"""
-        if "setup.py install" in line:
-            return False
+        if isinstance(x, str):
+            x = [x]
+        elif not isinstance(x, list):
+            return True
+        for line in x:
+            if "setup.py install" in line:
+                return False
         return True
 
     def check_recipe(self, recipe):
         for package in recipe.packages.values():
-            if not self._check_line(recipe.get(f"{package.path_prefix}build/script", "")):
+            if not self._check_line(recipe.get(f"{package.path_prefix}build/script", None)):
                 self.message(
                     section=f"{package.path_prefix}build/script",
                     data=(recipe, f"{package.path_prefix}build/script"),
                 )
-            elif not self._check_line(recipe.get(f"{package.path_prefix}/script", "")):
+            elif not self._check_line(recipe.get(f"{package.path_prefix}script", None)):
                 self.message(
                     section=f"{package.path_prefix}script",
                     data=(recipe, f"{package.path_prefix}script"),
@@ -448,12 +453,12 @@ class pip_install_args(LintCheck):
 
     def check_recipe(self, recipe):
         for package in recipe.packages.values():
-            if not self._check_line(recipe.get(f"{package.path_prefix}build/script", "")):
+            if not self._check_line(recipe.get(f"{package.path_prefix}build/script", None)):
                 self.message(
                     section=f"{package.path_prefix}build/script",
                     data=(recipe, f"{package.path_prefix}build/script"),
                 )
-            elif not self._check_line(recipe.get(f"{package.path_prefix}/script", "")):
+            elif not self._check_line(recipe.get(f"{package.path_prefix}script", None)):
                 self.message(
                     section=f"{package.path_prefix}script",
                     data=(recipe, f"{package.path_prefix}script"),

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -188,7 +188,7 @@ class cbc_dep_in_run_missing_from_host(LintCheck):
 
 
 class potentially_bad_ignore_run_exports(LintCheck):
-    """Ignoring run_export of a host dependency. In some cases it is more appropriate to remove the --error-overdepending flag of conda-build."""   # noqa: E501
+    """Ignoring run_export of a host dependency. In some cases it is more appropriate to remove the --error-overdepending flag of conda-build."""  # noqa: E501
 
     def check_recipe(self, recipe):
         for package in recipe.packages.values():

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -187,6 +187,16 @@ class cbc_dep_in_run_missing_from_host(LintCheck):
         return recipe.patch(op)
 
 
+class potentially_bad_ignore_run_exports(LintCheck):
+    """Ignoring run_export of a host dependency. In some cases it is more appropriate to remove the --error-overdepending flag of conda-build."""
+
+    def check_recipe(self, recipe):
+        for package in recipe.packages.values():
+            for dep in package.host:
+                if dep.pkg in package.ignore_run_exports:
+                    self.message(section=_utils.get_dep_path(recipe, dep), severity=INFO)
+
+
 class should_use_compilers(LintCheck):
     """The recipe requires a compiler directly
 

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -188,7 +188,7 @@ class cbc_dep_in_run_missing_from_host(LintCheck):
 
 
 class potentially_bad_ignore_run_exports(LintCheck):
-    """Ignoring run_export of a host dependency. In some cases it is more appropriate to remove the --error-overdepending flag of conda-build."""
+    """Ignoring run_export of a host dependency. In some cases it is more appropriate to remove the --error-overdepending flag of conda-build."""   # noqa: E501
 
     def check_recipe(self, recipe):
         for package in recipe.packages.values():

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -391,3 +391,26 @@ class missing_description(LintCheck):
     def check_recipe(self, recipe):
         if not recipe.get("about/description", ""):
             self.message(section="about", severity=WARNING)
+
+
+class wrong_output_script_key(LintCheck):
+    """It should be `outputs/x/script`, not `outputs/x/build/script`
+
+    Please change from::
+        outputs:
+          - name: output1
+            build:
+              script: build_script.sh
+
+    To::
+
+        outputs:
+          - name: output1
+            script: build_script.sh
+    """
+
+    def check_recipe(self, recipe):
+        for package in recipe.packages.values():
+            if package.path_prefix.startswith("outputs"):
+                if recipe.get(f"{package.path_prefix}build/script", None):
+                    self.message(section=f"{package.path_prefix}build/script")

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -121,3 +121,5 @@ yaml_load_failure
 missing_package_name
 
 missing_package_version
+
+cbc_dep_in_run_missing_from_host

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -125,3 +125,5 @@ missing_package_version
 cbc_dep_in_run_missing_from_host
 
 wrong_output_script_key
+
+potentially_bad_ignore_run_exports

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -123,3 +123,5 @@ missing_package_name
 missing_package_version
 
 cbc_dep_in_run_missing_from_host
+
+wrong_output_script_key

--- a/anaconda_linter/utils.py
+++ b/anaconda_linter/utils.py
@@ -213,6 +213,15 @@ def ensure_list(obj):
     return [obj]
 
 
+def get_dep_path(recipe, dep):
+    for n, spec in enumerate(recipe.get(dep.path, [])):
+        if spec is None:  # Fixme: lint this
+            continue
+        if spec == dep.raw_dep:
+            return f"{dep.path}/{n}"
+    return dep.path
+
+
 def get_deps_dict(recipe, sections=None, outputs=True):
     if not sections:
         sections = ("build", "run", "host")

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,7 +8,7 @@ dependencies:
   - setuptools
   - pip
   # run
-  - percy ==0.0.5
+  - percy >=0.1.0,<0.2.0
   - ruamel.yaml
   - license-expression
   - jinja2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - conda-build
     - jsonschema
     - networkx
-    - percy ==0.0.5
+    - percy >=0.1.0,<0.2.0
 
 test:
   source_files:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,14 +35,17 @@ def recipe_dir(tmpdir):
     return recipe_directory
 
 
-def check(check_name, recipe_str, arch="linux-64"):
+def check(check_name, recipe_str, arch="linux-64", expand_variant=None):
     config_file = Path(__file__).parent / "config.yaml"
     config = utils.load_config(str(config_file.resolve()))
     linter = Linter(config=config)
+    variant = config[arch]
+    if expand_variant:
+        variant.update(expand_variant)
     recipe = Recipe.from_string(
         recipe_text=recipe_str,
         variant_id="dummy",
-        variant=config[arch],
+        variant=variant,
         renderer=RendererType.RUAMEL,
     )
     messages = linter.check_instances[check_name].run(recipe=recipe)

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -3078,3 +3078,79 @@ def test_cbc_dep_in_run_missing_from_host_bad_multi(base_yaml):
     lint_check = "cbc_dep_in_run_missing_from_host"
     messages = check(lint_check, yaml_str, "linux-64", {"hdf5": "1.2.3"})
     assert len(messages) == 2
+
+
+def test_potentially_bad_ignore_run_exports_good(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+
+        build:
+          ignore_run_exports:
+            - bb
+        requirements:
+            host:
+              - aa
+        """
+    )
+    lint_check = "potentially_bad_ignore_run_exports"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_potentially_bad_ignore_run_exports_good_multi(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+
+        outputs:
+          - name: output1
+            build:
+              ignore_run_exports:
+                - bb
+            requirements:
+              host:
+                - aa
+        """
+    )
+    lint_check = "potentially_bad_ignore_run_exports"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_potentially_bad_ignore_run_exports_bad(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+
+        build:
+          ignore_run_exports:
+            - aa
+        requirements:
+            host:
+              - aa
+        """
+    )
+    lint_check = "potentially_bad_ignore_run_exports"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 1
+
+
+def test_potentially_bad_ignore_run_exports_bad_multi(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+
+        outputs:
+          - name: output1
+            build:
+              ignore_run_exports:
+                - aa
+            requirements:
+              host:
+                - aa
+        """
+    )
+    lint_check = "potentially_bad_ignore_run_exports"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 1

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -159,7 +159,10 @@ def test_host_section_needs_exact_pinnings_bad(base_yaml, constraint):
     )
     lint_check = "host_section_needs_exact_pinnings"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and "must have exact version pinnings" in messages[0].title
+    assert (
+        len(messages) == 1
+        and "Linked libraries host should have exact version pinnings." in messages[0].title
+    )
 
 
 @pytest.mark.parametrize("constraint", ("", ">=0.13", "<0.14", "!=0.13.7"))
@@ -181,7 +184,7 @@ def test_host_section_needs_exact_pinnings_bad_multi(base_yaml, constraint):
     lint_check = "host_section_needs_exact_pinnings"
     messages = check(lint_check, yaml_str)
     assert len(messages) == 2 and all(
-        "must have exact version pinnings" in msg.title for msg in messages
+        "Linked libraries host should have exact version pinnings." in msg.title for msg in messages
     )
 
 
@@ -2986,3 +2989,92 @@ def test_gui_app_bad(base_yaml, gui):
     )
     messages = check(lint_check, yaml_str)
     assert len(messages) == 1 and "GUI application" in messages[0].title
+
+
+def test_cbc_dep_in_run_missing_from_host_good(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        requirements:
+            host:
+              - python
+              - hdf5
+            run:
+              - python
+              - hdf5
+        """
+    )
+    lint_check = "cbc_dep_in_run_missing_from_host"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_cbc_dep_in_run_missing_from_host_good_multi(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        outputs:
+          - name: output1
+            requirements:
+              host:
+                - python
+                - hdf5
+              run:
+                - python
+                - hdf5
+          - name: output2
+            requirements:
+              host:
+                - python
+                - hdf5
+              run:
+                - python
+                - hdf5
+        """
+    )
+    lint_check = "cbc_dep_in_run_missing_from_host"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_cbc_dep_in_run_missing_from_host_bad(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        requirements:
+            host:
+              - python
+            run:
+              - python
+              - hdf5
+        """
+    )
+    lint_check = "cbc_dep_in_run_missing_from_host"
+    messages = check(lint_check, yaml_str, "linux-64", {"hdf5": "1.2.3"})
+    assert len(messages) == 1
+
+
+def test_cbc_dep_in_run_missing_from_host_bad_multi(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        outputs:
+          - name: output1
+            requirements:
+              host:
+                - python
+              run:
+                - python
+                - hdf5
+          - name: output2
+            requirements:
+              host:
+                - python
+              run:
+                - python
+                - hdf5
+        """
+    )
+    lint_check = "cbc_dep_in_run_missing_from_host"
+    messages = check(lint_check, yaml_str, "linux-64", {"hdf5": "1.2.3"})
+    assert len(messages) == 2

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -650,3 +650,32 @@ def test_missing_description_bad(base_yaml):
     lint_check = "missing_description"
     messages = check(lint_check, yaml_str)
     assert len(messages) == 1 and "missing a description" in messages[0].title
+
+
+def test_wrong_output_script_key_good(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        outputs:
+          - name: output1
+            script: build_script.sh
+        """
+    )
+    lint_check = "wrong_output_script_key"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_wrong_output_script_key_bad(base_yaml):
+    yaml_str = (
+        base_yaml
+        + """
+        outputs:
+          - name: output1
+            build:
+              script: build_script.sh
+        """
+    )
+    lint_check = "wrong_output_script_key"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 1


### PR DESCRIPTION
Changes:
- Add knowledge of Python build backends to the missing_wheel rule
- Relax host_section_needs_exact_pinnings
- Add cbc_dep_in_run_missing_from_host
- Make uses_setup_py an error
- Add auto-fix for cbc_dep_in_run_missing_from_host, uses_setup_py, pip_install_args
- Update percy to >=0.1.0,<0.2.0
- Add wrong_output_script_key
- Add potentially_bad_ignore_run_exports
- 
Goal is to make a linter release after this is merged.