### PR TITLE
Handle script not being remotely a file

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -414,7 +414,7 @@ class uses_setup_py(LintCheck):
                                     else:
                                         output = -1
                                     self.message(fname=build_file, line=num, output=output)
-                except FileNotFoundError:
+                except (FileNotFoundError, TypeError):
                     pass
 
     def fix(self, _message, _data):
@@ -482,7 +482,7 @@ class pip_install_args(LintCheck):
                                     else:
                                         output = -1
                                     self.message(fname=build_file, line=num, output=output)
-                except FileNotFoundError:
+                except (FileNotFoundError, TypeError):
                     pass
 
     def fix(self, _message, _data):


### PR DESCRIPTION
```
  script:
    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
```
A check was tripping on script: not being something that could pass as a file name.