### PR TITLE
Fully enforces `pylint` on the project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,8 @@
 # as-is.
 exclude: |
   (?x)^(
-    tests/test_aux_files/.*|
-    anaconda_linter/.*|
     docs/.*|
-    scripts/.*|
     setup.py|
-    tests/.*
   )$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,9 @@
 #   pre-commit run --all-files
 # Update this file:
 #   pre-commit autoupdate
-# TODO remove when other files are updated to pass. NOTE: keep the first line
-# as-is.
 exclude: |
   (?x)^(
+    tests/test_aux_files/.*|
     docs/.*|
     setup.py|
   )$

--- a/.pylintrc
+++ b/.pylintrc
@@ -223,7 +223,8 @@ class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
 inlinevar-rgx=^[a-z][a-z0-9_]*$
 
 # Regular expression matching correct class names
-class-rgx=^_?[A-Z][a-zA-Z0-9]*$
+# Anaconda Delta: (Specific to anaconda-linter) class names can be snake-cased to match the linting rules styling.
+class-rgx=^_?[a-zA-Z0-9_]*$
 
 # Regular expression matching correct module names
 module-rgx=^(_?[a-z][a-z0-9_]*|__init__)$

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ export PRINT_HELP_PYSCRIPT
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
 # For now, most tools only run on new files, not the entire project.
-LINTER_FILES := tests/*.py
+MYPY_FILES := anaconda_linter/lint/*.py tests/*.py
 # Tracks all python files. This will eventually be used by the auto formatter, linter, and static analyzer.
 ALL_PY_FILES := anaconda_linter/**/*.py scripts/*.py tests/*.py
 
@@ -111,11 +111,11 @@ test-cov:		## checks test coverage requirements
 		--cov-report term-missing
 
 lint:			## runs the linter against the project
-	pylint --rcfile=.pylintrc $(LINTER_FILES)
+	pylint --rcfile=.pylintrc $(ALL_PY_FILES)
 
 format:			## runs the code auto-formatter
 	isort --profile black --line-length=120 $(ALL_PY_FILES)
 	black --line-length=120 $(ALL_PY_FILES)
 
 analyze:		## runs static analyzer on the project
-	mypy --config-file=.mypy.ini $(LINTER_FILES)
+	mypy --config-file=.mypy.ini $(MYPY_FILES)

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ BROWSER := python -c "$$BROWSER_PYSCRIPT"
 # For now, most tools only run on new files, not the entire project.
 MYPY_FILES := anaconda_linter/lint/*.py tests/*.py
 # Tracks all python files. This will eventually be used by the auto formatter, linter, and static analyzer.
-ALL_PY_FILES := anaconda_linter/**/*.py scripts/*.py tests/*.py
+ALL_PY_FILES := anaconda_linter/*.py anaconda_linter/**/*.py scripts/*.py tests/*.py
 
 clean: clean-cov clean-build clean-env clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
 

--- a/anaconda_linter/__init__.py
+++ b/anaconda_linter/__init__.py
@@ -1,4 +1,8 @@
-__name__ = "anaconda_linter"
+"""
+File:           __init__.py
+Description:    Module configurations for the `anaconda-linter` project
+"""
+__name__ = "anaconda_linter"  # pylint: disable=redefined-builtin
 __version__ = "0.1.1"
 __author__ = "Anaconda, Inc."
 __email__ = "distribution_team@anaconda.com"

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -1,7 +1,8 @@
-"""Completeness
-
-Verify that the recipe is not missing anything essential.
 """
+File:           check_completeness.py
+Description:    Contains linter checks for missing essential information.
+"""
+from __future__ import annotations
 
 import os
 import re

--- a/anaconda_linter/lint/check_multi_output.py
+++ b/anaconda_linter/lint/check_multi_output.py
@@ -1,3 +1,9 @@
+"""
+File:           check_multi_output.py
+Description:    Contains linter checks for multi-output based rules.
+"""
+from __future__ import annotations
+
 from anaconda_linter import utils as _utils
 from anaconda_linter.lint import INFO, WARNING, LintCheck
 

--- a/anaconda_linter/lint/check_spdx.py
+++ b/anaconda_linter/lint/check_spdx.py
@@ -1,7 +1,8 @@
-"""Syntax
-
-Verify that the recipe's syntax is correct.
 """
+File:           check_spdx.py
+Description:    Contains linter checks for SPDX licensing database based rules.
+"""
+from __future__ import annotations
 
 import os
 import re
@@ -28,12 +29,12 @@ class incorrect_license(LintCheck):
 
     def check_recipe(self, recipe):
         licensing = license_expression.Licensing()
-        license = recipe.get("about/license", "")
+        license = recipe.get("about/license", "")  # pylint: disable=redefined-builtin
         parsed_exceptions = []
         try:
             parsed_licenses = []
             parsed_licenses_with_exception = licensing.license_symbols(license.strip(), decompose=False)
-            for l in parsed_licenses_with_exception:  # noqa
+            for l in parsed_licenses_with_exception:
                 if isinstance(l, license_expression.LicenseWithExceptionSymbol):
                     parsed_licenses.append(l.license_symbol.key)
                     parsed_exceptions.append(l.exception_symbol.key)
@@ -44,16 +45,16 @@ class incorrect_license(LintCheck):
 
         licenseref_regex = re.compile(r"^LicenseRef[a-zA-Z0-9\-.]*$")
         filtered_licenses = []
-        for license in parsed_licenses:
-            if not licenseref_regex.match(license):
-                filtered_licenses.append(license)
+        for parsed_license in parsed_licenses:
+            if not licenseref_regex.match(parsed_license):
+                filtered_licenses.append(parsed_license)
 
-        with open(os.path.join(os.path.dirname(__file__), LICENSES_PATH)) as f:
+        with open(os.path.join(os.path.dirname(__file__), LICENSES_PATH), encoding="utf-8") as f:
             expected_licenses = f.readlines()
-            expected_licenses = {l.strip() for l in expected_licenses}  # noqa
-        with open(os.path.join(os.path.dirname(__file__), EXCEPTIONS_PATH)) as f:
+            expected_licenses = {l.strip() for l in expected_licenses}
+        with open(os.path.join(os.path.dirname(__file__), EXCEPTIONS_PATH), encoding="utf-8") as f:
             expected_exceptions = f.readlines()
-            expected_exceptions = {l.strip() for l in expected_exceptions}  # noqa
+            expected_exceptions = {l.strip() for l in expected_exceptions}
         non_spdx_licenses = set(filtered_licenses) - expected_licenses
         if non_spdx_licenses:
             for license in non_spdx_licenses:

--- a/anaconda_linter/lint/check_syntax.py
+++ b/anaconda_linter/lint/check_syntax.py
@@ -1,9 +1,9 @@
-"""Syntax checks
-
-These checks verify syntax (schema), in particular for the ``extra``
-section that is otherwise free-form.
-
 """
+File:           check_syntax.py
+Description:    Contains linter checks for syntax rules.
+"""
+from __future__ import annotations
+
 import re
 
 from anaconda_linter.lint import LintCheck
@@ -40,7 +40,7 @@ class version_constraints_missing_whitespace(LintCheck):
                     if not space_separated:
                         self.message(section=f"{path}/{n}", data=True, output=output)
 
-    def fix(self, _message, _data):
+    def fix(self, message, data):
         check_paths = []
         for section in ("build", "run", "host"):
             check_paths.append(f"requirements/{section}")

--- a/anaconda_linter/lint/check_url.py
+++ b/anaconda_linter/lint/check_url.py
@@ -1,8 +1,8 @@
 """
-Check URL
-
-Verify that the URLs in the recipe are valid
+File:           check_url.py
+Description:    Contains linter checks for URL validation.
 """
+from __future__ import annotations
 
 from anaconda_linter import utils
 from anaconda_linter.lint import ERROR, INFO, LintCheck
@@ -69,4 +69,4 @@ class http_url(LintCheck):
         ]
         for url_field in url_fields:
             url = recipe.get(url_field, "")
-            self._check_url(url, url_field.split("/")[0])
+            self._check_url(url, url_field.split("/", maxsplit=1)[0])

--- a/anaconda_linter/run.py
+++ b/anaconda_linter/run.py
@@ -102,18 +102,14 @@ def main():
     config = utils.load_config(config_file)
 
     # set up linter
-    linter = lint.Linter(
-        config=config, verbose=args.verbose, exclude=None, nocatch=True, severity_min=args.severity
-    )
+    linter = lint.Linter(config=config, verbose=args.verbose, exclude=None, nocatch=True, severity_min=args.severity)
 
     # run linter
     recipes = [f"{args.recipe}/recipe/"]
     messages = set()
     overall_result = 0
     for subdir in args.subdirs:
-        result = linter.lint(
-            recipes, subdir, args.variant_config_files, args.exclusive_config_files, args.fix
-        )
+        result = linter.lint(recipes, subdir, args.variant_config_files, args.exclusive_config_files, args.fix)
         if result > overall_result:
             overall_result = result
         messages = messages | set(linter.get_messages())

--- a/anaconda_linter/run.py
+++ b/anaconda_linter/run.py
@@ -1,3 +1,9 @@
+"""
+File:           run.py
+Description:    Primary execution point of the linter's CLI
+"""
+from __future__ import annotations
+
 import argparse
 import os
 import textwrap
@@ -6,6 +12,11 @@ from anaconda_linter import __version__, lint, utils
 
 
 def lint_parser() -> argparse.ArgumentParser:
+    """
+    Configures the `argparser` instance used for the linter's CLI
+    :return: An `argparser` instance to parse command line arguments
+    """
+
     def check_path(value):
         if not os.path.isdir(value):
             raise argparse.ArgumentTypeError(f"The specified directory {value} does not exist")
@@ -93,6 +104,9 @@ def lint_parser() -> argparse.ArgumentParser:
 
 
 def main():
+    """
+    Primary execution point of the linter's CLI
+    """
     # parse arguments
     parser = lint_parser()
     args, _ = parser.parse_known_args()

--- a/anaconda_linter/utils.py
+++ b/anaconda_linter/utils.py
@@ -38,10 +38,10 @@ def validate_config(config):
         directly.
     """
     if not isinstance(config, dict):
-        with open(config) as conf:
+        with open(config, encoding="utf-8") as conf:
             config = yaml.load(conf.read())
     fn = os.path.abspath(os.path.dirname(__file__)) + "/config.schema.yaml"
-    with open(fn) as f:
+    with open(fn, encoding="utf-8") as f:
         schema = yaml.load(f.read())
     validate(config, schema)
 
@@ -68,7 +68,7 @@ def load_config(path):
         def relpath(p):
             return os.path.join(os.path.dirname(path), p)
 
-        with open(path) as conf:
+        with open(path, encoding="utf-8") as conf:
             config = yaml.load(conf.read())
 
     def get_list(key):
@@ -87,13 +87,13 @@ def load_config(path):
     default_config.update(config)
 
     # store architecture information
-    with open(Path(__file__).parent / "data" / "cbc_default.yaml") as text:
+    with open(Path(__file__, encoding="utf-8").parent / "data" / "cbc_default.yaml") as text:
         init_arch = yaml.load(text.read())
         data_path = Path(__file__).parent / "data"
         for arch_config_path in data_path.glob("cbc_*.yaml"):
             arch = arch_config_path.stem.split("cbc_")[1]
             if arch != "default":
-                with open(arch_config_path) as text:
+                with open(arch_config_path, encoding="utf-8") as text:
                     default_config[arch] = deepcopy(init_arch)
                     default_config[arch].update(yaml.load(text.read()))
 
@@ -152,7 +152,7 @@ def check_url(url):
 
 
 def generate_correction(pkg_license, compfile=Path(__file__).parent / "data" / "licenses.txt"):
-    with open(compfile) as f:
+    with open(compfile, encoding="utf-8") as f:
         words = f.readlines()
 
     words = [w.strip("\n") for w in words]

--- a/anaconda_linter/utils.py
+++ b/anaconda_linter/utils.py
@@ -1,9 +1,10 @@
 """
-Utility Functions and Classes
-
-This module collects small pieces of code used throughout
-:py:mod:`anaconda_linter`.
+File:           utils.py
+Description:    Utility Functions and Classes
+                This module collects small pieces of code used throughout
+                :py:mod:`anaconda_linter`.
 """
+from __future__ import annotations
 
 import logging
 import os
@@ -11,15 +12,18 @@ import re
 from collections import Counter
 from copy import deepcopy
 from pathlib import Path
-from typing import Sequence
+from typing import Final, Optional, Sequence
 
 import requests
 from jsonschema import validate
+from percy.render.recipe import Recipe
 
 try:
     from ruamel.yaml import YAML
 except ModuleNotFoundError:
     from ruamel_yaml import YAML
+
+HTTP_TIMEOUT: Final[int] = 120
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +91,7 @@ def load_config(path):
     default_config.update(config)
 
     # store architecture information
-    with open(Path(__file__, encoding="utf-8").parent / "data" / "cbc_default.yaml") as text:
+    with open(Path(__file__).parent / "data" / "cbc_default.yaml", encoding="utf-8") as text:
         init_arch = yaml.load(text.read())
         data_path = Path(__file__).parent / "data"
         for arch_config_path in data_path.glob("cbc_*.yaml"):
@@ -121,7 +125,7 @@ def check_url(url):
     if url not in check_url_cache:
         response_data = {"url": url}
         try:
-            response = requests.head(url, allow_redirects=False)
+            response = requests.head(url, allow_redirects=False, timeout=HTTP_TIMEOUT)
             if response.status_code >= 200 and response.status_code < 400:
                 origin_domain = requests.utils.urlparse(url).netloc
                 redirect_domain = origin_domain
@@ -142,49 +146,56 @@ def check_url(url):
         except requests.HTTPError as e:
             response_data["code"] = e.response.status_code
             response_data["message"] = e.response.text
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-exception-caught
             response_data["code"] = -1
             response_data["message"] = str(e)
         check_url_cache[url] = response_data
     return check_url_cache[url]
 
 
-def generate_correction(pkg_license, compfile=Path(__file__).parent / "data" / "licenses.txt"):
+def generate_correction(pkg_license: str, compfile: Path = Path(__file__).parent / "data" / "licenses.txt") -> str:
+    """
+    Uses a probabilistic model to generate corrections on a license file
+    TODO: Evaluate if this is the best method to use
+    :param pkg_license: Contents of the license file to correct, as a string.
+    :param compfile:    Path to a license file to compare/diff against.
+    :return: Modified version of the original license file string.
+    """
     with open(compfile, encoding="utf-8") as f:
         words = f.readlines()
 
-    words = [w.strip("\n") for w in words]
-    WORDS = Counter(words)
+    words: list[str] = [w.strip("\n") for w in words]
+    words_cntr: Final[Counter] = Counter(words)
 
-    def P(word, N=sum(WORDS.values())):
+    def probability(word: str, n=sum(words_cntr.values())):
         "Probability of `word`."
-        return WORDS[word] / N
+        return words_cntr[word] / n
 
-    def correction(word):
+    def correction(word: str) -> str:
         "Most probable spelling correction for word."
-        return max(candidates(word), key=P)
+        return max(candidates(word), key=probability)
 
-    def candidates(word):
+    def candidates(word: str):
         "Generate possible spelling corrections for word."
         return known([word]) or known(edits1(word)) or known(edits2(word)) or [word]
 
-    def known(words):
-        "The subset of `words` that appear in the dictionary of WORDS."
-        return {w for w in words if w in WORDS}
+    def known(words: list[str]):
+        "The subset of `words` that appear in the dictionary of `words_cntr`."
+        return {w for w in words if w in words_cntr}
 
-    def edits1(word):
+    def edits1(word: str):
         "All edits that are one edit away from `word`."
         letters = "abcdefghijklmnopqrstuvwxyz"
         symbols = "-.0123456789"
         letters += letters.upper() + symbols
         splits = [(word[:i], word[i:]) for i in range(len(word) + 1)]
-        deletes = [L + R[1:] for L, R in splits if R]
-        transposes = [L + R[1] + R[0] + R[2:] for L, R in splits if len(R) > 1]
-        replaces = [L + c + R[1:] for L, R in splits if R for c in letters]
-        inserts = [L + c + R for L, R in splits for c in letters]
+        deletes = [l + r[1:] for l, r in splits if r]
+        transposes = [l + r[1] + r[0] + r[2:] for l, r in splits if len(r) > 1]
+        replaces = [l + c + r[1:] for l, r in splits if r for c in letters]
+        inserts = [l + c + r for l, r in splits for c in letters]
         return set(deletes + transposes + replaces + inserts)
 
-    def edits2(word):
+    def edits2(word: str):
         "All edits that are two edits away from `word`."
         return (e2 for e1 in edits1(word) for e2 in edits1(e1))
 
@@ -220,9 +231,16 @@ def get_dep_path(recipe, dep):
     return dep.path
 
 
-def get_deps_dict(recipe, sections=None, outputs=True):
-    if not sections:
-        sections = ("build", "run", "host")
+def get_deps_dict(recipe: Recipe, sections: Optional[list[str]] = None, outputs: bool = True) -> dict[str : list[str]]:
+    """
+    Returns a dictionary containing lists of recipe dependencies.
+    TODO Future: Look into removing the `outputs` flag and query `recipe` if it has an outputs section.
+    :param recipe:      Target recipe instance
+    :param sections:    (Optional)  List of strings
+    :param outputs:     (Optional) Set to True for recipes that have an `outputs` section
+    """
+    if sections is None:
+        sections = ["build", "run", "host"]
     else:
         sections = ensure_list(sections)
     check_paths = []
@@ -232,7 +250,7 @@ def get_deps_dict(recipe, sections=None, outputs=True):
         for section in sections:
             for n in range(len(recipe.get("outputs", []))):
                 check_paths.append(f"outputs/{n}/requirements/{section}")
-    deps = {}
+    deps: dict[str : list[str]] = {}
     for path in check_paths:
         for n, spec in enumerate(recipe.get(path, [])):
             if spec is None:  # Fixme: lint this

--- a/anaconda_linter/utils.py
+++ b/anaconda_linter/utils.py
@@ -129,9 +129,7 @@ def check_url(url):
                     redirect_domain = requests.utils.urlparse(response.headers["Location"]).netloc
                 if origin_domain != redirect_domain:  # For redirects to other domain
                     response_data["code"] = -1
-                    response_data[
-                        "message"
-                    ] = f"URL domain redirect {origin_domain} ->  {redirect_domain}"
+                    response_data["message"] = f"URL domain redirect {origin_domain} ->  {redirect_domain}"
                     response_data["url"] = response.headers["Location"]
                     response_data["domain_origin"] = origin_domain
                     response_data["domain_redirect"] = redirect_domain

--- a/scripts/update_licenses.py
+++ b/scripts/update_licenses.py
@@ -11,9 +11,10 @@ from typing import Final, List
 
 import requests
 
+from anaconda_linter.utils import HTTP_TIMEOUT
+
 LICENSES: Final[str] = "https://raw.githubusercontent.com/spdx/license-list-data/main/json/licenses.json"
 EXCEPTIONS: Final[str] = "https://raw.githubusercontent.com/spdx/license-list-data/main/json/exceptions.json"
-HTTP_TIMEOUT: Final[int] = 120
 
 
 def write_to_file(dest_file: Path or str, data: List[str]):

--- a/tests/test_build_help.py
+++ b/tests/test_build_help.py
@@ -1,3 +1,7 @@
+"""
+File:           test_build_help.py
+Description:    Tests build section rules
+"""
 from __future__ import annotations
 
 import pytest
@@ -1591,7 +1595,7 @@ def test_patch_must_be_in_build_bad(base_yaml):
             )
             messages = check(lint_check, yaml_str)
             assert (
-                len(messages) == 1 and "patch must be in build" and messages[0].title
+                len(messages) == 1 and "patch must be in build" in messages[0].title
             ), f"Check failed for {patch} in {section}"
 
 
@@ -1613,7 +1617,7 @@ def test_patch_must_be_in_build_list_bad(base_yaml, patch, section):
         """
     )
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and "patch must be in build" and messages[0].title
+    assert len(messages) == 1 and "patch must be in build" in messages[0].title
 
 
 def test_patch_must_be_in_build_missing(base_yaml):
@@ -2581,7 +2585,7 @@ def test_missing_python_url_bad(base_yaml):
     )
     lint_check = "missing_python"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 2 and all(["python should be present" in m.title for m in messages])
+    assert len(messages) == 2 and all("python should be present" in m.title for m in messages)
 
 
 def test_missing_python_pip_install_good(base_yaml):
@@ -2694,7 +2698,7 @@ def test_missing_python_pip_install_bad(base_yaml):
     )
     lint_check = "missing_python"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 2 and all(["python should be present" in m.title for m in messages])
+    assert len(messages) == 2 and all("python should be present" in m.title for m in messages)
 
 
 def test_missing_python_pip_install_bad_list(base_yaml):
@@ -2710,7 +2714,7 @@ def test_missing_python_pip_install_bad_list(base_yaml):
     )
     lint_check = "missing_python"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 2 and all(["python should be present" in m.title for m in messages])
+    assert len(messages) == 2 and all("python should be present" in m.title for m in messages)
 
 
 def test_missing_python_pip_install_bad_multi(base_yaml):
@@ -2728,7 +2732,7 @@ def test_missing_python_pip_install_bad_multi(base_yaml):
     )
     lint_check = "missing_python"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 4 and all(["python should be present" in m.title for m in messages])
+    assert len(messages) == 4 and all("python should be present" in m.title for m in messages)
 
 
 def test_missing_python_pip_install_bad_multi_list(base_yaml):
@@ -2747,7 +2751,7 @@ def test_missing_python_pip_install_bad_multi_list(base_yaml):
     )
     lint_check = "missing_python"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 4 and all(["python should be present" in m.title for m in messages])
+    assert len(messages) == 4 and all("python should be present" in m.title for m in messages)
 
 
 def test_remove_python_pinning_good(base_yaml):
@@ -2831,7 +2835,7 @@ def test_remove_python_pinning_bad_multi(base_yaml):
 
 
 @pytest.mark.parametrize("arch", ("linux-64", "win-64"))
-def test_no_git_on_windows_good(base_yaml, arch):
+def test_no_git_on_windows_good(base_yaml, arch):  # pylint: disable=unused-argument
     yaml_str = (
         base_yaml
         + """
@@ -2860,7 +2864,7 @@ def test_no_git_on_windows_bad(base_yaml):
 
 
 @pytest.mark.parametrize("arch", ("linux-64", "win-64"))
-def test_no_git_on_windows_good_multi(base_yaml, arch):
+def test_no_git_on_windows_good_multi(base_yaml, arch):  # pylint: disable=unused-argument
     yaml_str = (
         base_yaml
         + """

--- a/tests/test_completeness.py
+++ b/tests/test_completeness.py
@@ -1,3 +1,9 @@
+"""
+File:           test_completeness.py
+Description:    Tests completeness rules (i.e. `missing_*`)
+"""
+from __future__ import annotations
+
 import pytest
 from conftest import check, check_dir
 
@@ -83,7 +89,7 @@ def test_missing_build_number_bad(base_yaml):
     assert len(messages) == 1 and "missing a build number" in messages[0].title
 
 
-def test_missing_package_name_good(base_yaml):
+def test_missing_package_name_good(base_yaml):  # pylint: disable=unused-argument
     yaml_str = """
         package:
           name: plop
@@ -93,7 +99,7 @@ def test_missing_package_name_good(base_yaml):
     assert len(messages) == 0
 
 
-def test_missing_package_name_bad(base_yaml):
+def test_missing_package_name_bad(base_yaml):  # pylint: disable=unused-argument
     yaml_str = """
         build:
           number: 0
@@ -103,7 +109,7 @@ def test_missing_package_name_bad(base_yaml):
     assert len(messages) == 1 and "missing a package name" in messages[0].title
 
 
-def test_missing_package_version_good(base_yaml):
+def test_missing_package_version_good(base_yaml):  # pylint: disable=unused-argument
     yaml_str = """
         package:
           version: 1.2.3
@@ -113,7 +119,7 @@ def test_missing_package_version_good(base_yaml):
     assert len(messages) == 0
 
 
-def test_missing_package_version_bad(base_yaml):
+def test_missing_package_version_bad(base_yaml):  # pylint: disable=unused-argument
     yaml_str = """
         build:
           number: 0
@@ -488,7 +494,7 @@ def test_missing_source_bad_type(base_yaml):
 
 
 @pytest.mark.parametrize("src_type", ("url", "git_url", "path"))
-def test_non_url_source_good(base_yaml, src_type):
+def test_non_url_source_good(base_yaml, src_type):  # pylint: disable=unused-argument
     yaml_str = (
         base_yaml
         + """

--- a/tests/test_multi_output.py
+++ b/tests/test_multi_output.py
@@ -1,3 +1,9 @@
+"""
+File:           test_multi_output.py
+Description:    Tests multi-output-based rules
+"""
+from __future__ import annotations
+
 import pytest
 from conftest import check
 

--- a/tests/test_spdx.py
+++ b/tests/test_spdx.py
@@ -1,7 +1,13 @@
+"""
+File:           test_spdx.py
+Description:    Tests licensing rules using the SPDX database
+"""
+from __future__ import annotations
+
 from conftest import check
 
 
-def test_spdx_good(linter, base_yaml):
+def test_spdx_good(linter, base_yaml):  # pylint: disable=unused-argument
     yaml_str = (
         base_yaml
         + """
@@ -14,7 +20,7 @@ def test_spdx_good(linter, base_yaml):
     assert len(messages) == 0
 
 
-def test_spdx_bad(linter, base_yaml):
+def test_spdx_bad(linter, base_yaml):  # pylint: disable=unused-argument
     yaml_str = (
         base_yaml
         + """
@@ -27,7 +33,7 @@ def test_spdx_bad(linter, base_yaml):
     assert len(messages) == 1 and "closest match" not in messages[0].title
 
 
-def test_spdx_close(linter, base_yaml):
+def test_spdx_close(linter, base_yaml):  # pylint: disable=unused-argument
     yaml_str = (
         base_yaml
         + """

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -1,3 +1,9 @@
+"""
+File:           test_syntax.py
+Description:    Tests syntax-based rules
+"""
+from __future__ import annotations
+
 from conftest import check
 
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1,3 +1,9 @@
+"""
+File:           test_url.py
+Description:    Tests URL-based rules
+"""
+from __future__ import annotations
+
 import pytest
 from conftest import check
 


### PR DESCRIPTION
There should be no net logic changes with this PR, with the exception of fixes to previously existing logic mistakes, found by the linter.

Initially I was not planning to perform all of these at once. But it turns out that there weren't nearly as many linting issues as I previously imagined.

So before we greatly expand this project with additional engineering resources, I wanted to enforce some rules now.

Notes:
- Expands class name regex to allow for snake-casing, to be consistent with linting rule names
- Linter is fully enabled in `pre-commit` and `make` commands for all `*.py` files (with some exceptions around the `docs/` and other non-critical files)
- I tried not to migrate all the docs to `sphinx` format. The linter (and mypy) config should allow both. I would prefer we all move to one, but we got bigger fish to fry right now.
- Fixes a number of logic errors
- Fixes a number of other linting errors