### PR TITLE
Fixes issue with crashing linter rule, adds missing unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,20 +62,3 @@ jobs:
             source $CONDA/bin/activate
             conda install conda-build
             conda-build -c distro-tooling .
-  lint-recipe:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-          with:
-            repository: AnacondaRecipes/anaconda-linter-feedstock
-            path: ./feedstock
-        - uses: ./.github/actions/setup-env
-          with:
-            python-version: "3.11"
-        - name: Run lint
-          run: |
-            cp -r ./feedstock/abs.yaml ./feedstock/recipe .
-            source $CONDA/bin/activate
-            conda activate anaconda-linter
-            conda-lint .

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -356,7 +356,10 @@ class LintCheck(metaclass=LintCheckMeta):
         """
         Attempt to automatically fix the linting error.
         :param message: Linting message emitted by the rule
-        :param data: Information vector for the rule to communicate to the fix. TODO: standardize typing for all callers
+        :param data: Information vector for the rule to communicate to the fix.
+                     TODO: All callers should fill out a custom `dict[str, Any]` and then cast the types to a variable
+                           inside of their overridden `fix()` function. Then the data structure is easily expandable but
+                           still custom to each function call.
         :returns: True if the fix succeeded. False otherwise
         """
         return False

--- a/anaconda_linter/lint/check_syntax.py
+++ b/anaconda_linter/lint/check_syntax.py
@@ -37,7 +37,6 @@ class version_constraints_missing_whitespace(LintCheck):
         # Search all dependencies for missing whitespace
         for path in check_paths:
             output: Final[int] = -1 if not path.startswith("/outputs") else int(path.split("/")[2])
-            n = int(path.split("/")[-1])
             spec = cast(str, ro_parser.get_value(path))
             has_constraints = version_constraints_missing_whitespace._CONSTRAINTS_RE.search(spec)
             if not has_constraints:
@@ -50,7 +49,7 @@ class version_constraints_missing_whitespace(LintCheck):
             dependency, version = has_constraints.groups()
             new_dependency: Final[str] = f"{dependency} {version}"
             self.message(
-                section=f"{path}/{n}",
+                section=path,
                 data={"path": path, "new_dependency": new_dependency},
                 output=output,
             )
@@ -59,7 +58,7 @@ class version_constraints_missing_whitespace(LintCheck):
         path = cast(str, data["path"])
         new_dependency = cast(str, data["new_dependency"])
 
-        def _rm_whitespace(parser: RecipeParser):
+        def _add_whitespace(parser: RecipeParser):
             selector: Final[str] = (
                 "" if not parser.contains_selector_at_path(path) else parser.get_selector_at_path(path)
             )
@@ -67,4 +66,4 @@ class version_constraints_missing_whitespace(LintCheck):
             if selector:
                 parser.add_selector(path, selector)
 
-        return self.recipe.patch_with_parser(_rm_whitespace)
+        return self.recipe.patch_with_parser(_add_whitespace)

--- a/anaconda_linter/lint/check_syntax.py
+++ b/anaconda_linter/lint/check_syntax.py
@@ -5,6 +5,9 @@ Description:    Contains linter checks for syntax rules.
 from __future__ import annotations
 
 import re
+from typing import Final, cast
+
+from percy.parser.recipe_parser import RecipeParser
 
 from anaconda_linter.lint import LintCheck
 
@@ -20,45 +23,48 @@ class version_constraints_missing_whitespace(LintCheck):
 
     """
 
-    def check_recipe(self, recipe) -> None:
-        check_paths = []
-        for section in ("build", "run", "host"):
-            check_paths.append(f"requirements/{section}")
-        if outputs := recipe.get("outputs", None):
-            for n in range(len(outputs)):
-                for section in ("build", "run", "host"):
-                    check_paths.append(f"outputs/{n}/requirements/{section}")
+    # TODO Future: percy should eventually have support for constraints. This regex may not be
+    # sufficient enough to catch all accepted formats
+    _CONSTRAINTS_RE: Final[re.Pattern[str]] = re.compile("(.*?)([!<=>].*)")
 
-        constraints = re.compile("(.*?)([!<=>].*)")
+    def check_recipe(self, recipe) -> None:
+        # Whitespace will be the same in all rendered forums of the recipe, so we use the RecipeParser infrastructure.
+        # TODO future: in these instances, recipes should not be rendered in all formats AND only look at the
+        # raw recipe file.
+        ro_parser: Final[RecipeParser] = recipe.get_read_only_parser()
+        check_paths: Final[list[str]] = ro_parser.get_dependency_paths()
+
+        # Search all dependencies for missing whitespace
         for path in check_paths:
-            output = -1 if not path.startswith("outputs") else int(path.split("/")[1])
-            for n, spec in enumerate(recipe.get(path, [])):
-                has_constraints = constraints.search(spec)
-                if has_constraints:
-                    # The second condition is a fallback.
-                    # See: https://github.com/anaconda-distribution/anaconda-linter/issues/113
-                    space_separated = has_constraints[1].endswith(" ") or " " in has_constraints[0]
-                    if not space_separated:
-                        self.message(section=f"{path}/{n}", data=True, output=output)
+            output: Final[int] = -1 if not path.startswith("/outputs") else int(path.split("/")[2])
+            n = int(path.split("/")[-1])
+            spec = cast(str, ro_parser.get_value(path))
+            has_constraints = version_constraints_missing_whitespace._CONSTRAINTS_RE.search(spec)
+            if not has_constraints:
+                continue
+            # The second condition is a fallback.
+            # See: https://github.com/anaconda-distribution/anaconda-linter/issues/113
+            space_separated = has_constraints[1].endswith(" ") or " " in has_constraints[0]
+            if space_separated:
+                continue
+            dependency, version = has_constraints.groups()
+            new_dependency: Final[str] = f"{dependency} {version}"
+            self.message(
+                section=f"{path}/{n}",
+                data={"path": path, "new_dependency": new_dependency},
+                output=output,
+            )
 
     def fix(self, message, data) -> bool:
-        check_paths = []
-        for section in ("build", "run", "host"):
-            check_paths.append(f"requirements/{section}")
-        if outputs := self.recipe.get("outputs", None):
-            for n in range(len(outputs)):
-                for section in ("build", "run", "host"):
-                    check_paths.append(f"outputs/{n}/requirements/{section}")
+        path = cast(str, data["path"])
+        new_dependency = cast(str, data["new_dependency"])
 
-        constraints = re.compile("(.*?)([!<=>].*)")
-        for path in check_paths:
-            for spec in self.recipe.get(path, []):
-                has_constraints = constraints.search(spec)
-                if has_constraints:
-                    # The second condition is a fallback.
-                    # See: https://github.com/anaconda-distribution/anaconda-linter/issues/113
-                    space_separated = has_constraints[1].endswith(" ") or " " in has_constraints[0]
-                    if not space_separated:
-                        dep, ver = has_constraints.groups()
-                        self.recipe.replace(spec, f"{dep} {ver}", within="requirements")
-        return True
+        def _rm_whitespace(parser: RecipeParser):
+            selector: Final[str] = (
+                "" if not parser.contains_selector_at_path(path) else parser.get_selector_at_path(path)
+            )
+            parser.patch({"op": "replace", "path": path, "value": new_dependency})
+            if selector:
+                parser.add_selector(path, selector)
+
+        return self.recipe.patch_with_parser(_rm_whitespace)

--- a/environment.yaml
+++ b/environment.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pip
   - make
   # run
-  - distro-tooling::percy >=0.1.3
+  - distro-tooling::percy >=0.1.5
   - distro-tooling::anaconda-packaging-utils
   - ruamel.yaml
   - license-expression

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ def check_dir(check_name: str, feedstock_dir: str | Path, recipe_str: str, arch:
     return messages
 
 
-def assert_on_auto_fix(check_name: str, suffix: str, arch: str) -> None:
+def assert_on_auto_fix(check_name: str, suffix: str, arch: str, num_occurrences: int) -> None:
     """
     Utility function executes a fix function against an offending recipe file. Then asserts the resulting file against
     a known fixed equivalent of the offending recipe file.
@@ -142,6 +142,8 @@ def assert_on_auto_fix(check_name: str, suffix: str, arch: str) -> None:
                             variants of input-to-expected-output files. If non-empty, the files should be named:
                             `<check_name>_<suffix>.yaml` and `<check_name>_<suffix>_fixed.yaml`, respectively.
     :param arch:            Target architecture to render recipe as
+    :param num_occurrences: How many times a rule should be expected to be found in the file. This allows for 1 set of
+                            test files to validate multiple variations of a rule.
     """
     suffix_adjusted: Final[str] = f"_{suffix}" if suffix else ""
     broken_file: Final[str] = f"{TEST_AUTO_FIX_FILES_PATH}/{check_name}{suffix_adjusted}.yaml"
@@ -154,9 +156,14 @@ def assert_on_auto_fix(check_name: str, suffix: str, arch: str) -> None:
     with patch("builtins.open", mock_open()):
         messages = linter_obj.check_instances[check_name].run(recipe=recipe, fix=True)
 
-    # Ensure that the rule triggered, that the correct rule triggered, and that the rule was actually fixed
-    assert len(messages) == 1
-    assert messages[0].auto_fix_state == AutoFixState.FIX_PASSED
-    assert str(messages[0].check) == check_name
+    # Ensure that:
+    #   - The rule triggered the expected number of times
+    #   - That the correct rule triggered
+    #   - And that the rule was actually fixed
+    # This supports
+    assert len(messages) == num_occurrences
+    for i in range(num_occurrences):
+        assert messages[i].auto_fix_state == AutoFixState.FIX_PASSED
+        assert str(messages[i].check) == check_name
     # Ensure that the output matches the expected output
     assert recipe.dump() == load_file(fixed_file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,15 +133,19 @@ def check_dir(check_name: str, feedstock_dir: str | Path, recipe_str: str, arch:
     return messages
 
 
-def assert_on_auto_fix(check_name: str, arch: str = "linux-64") -> None:
+def assert_on_auto_fix(check_name: str, suffix: str = "", arch: str = "linux-64") -> None:
     """
     Utility function executes a fix function against an offending recipe file. Then asserts the resulting file against
     a known fixed equivalent of the offending recipe file.
     :param check_name:      Name of the linting rule. This corresponds with input and output files.
+    :param suffix:          (Optional) Standardized suffix used in the file format. This allows us to test multiple
+                            variants of input-to-expected-output files. if specified, the files should be named:
+                            `<check_name>_<suffix>.yaml` and `<check_name>_<suffix>_fixed.yaml`, respectively.
     :param arch:            (Optional) Target architecture to render recipe as
     """
-    broken_file: Final[str] = f"{TEST_AUTO_FIX_FILES_PATH}/{check_name}.yaml"
-    fixed_file: Final[str] = f"{TEST_AUTO_FIX_FILES_PATH}/{check_name}_fixed.yaml"
+    suffix_adjusted: Final[str] = f"_{suffix}" if suffix else ""
+    broken_file: Final[str] = f"{TEST_AUTO_FIX_FILES_PATH}/{check_name}{suffix_adjusted}.yaml"
+    fixed_file: Final[str] = f"{TEST_AUTO_FIX_FILES_PATH}/{check_name}{suffix_adjusted}_fixed.yaml"
 
     linter_obj, recipe = load_linter_and_recipe(load_file(broken_file), arch)
 

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -14,20 +14,27 @@ import pytest
 from conftest import assert_on_auto_fix
 
 
-# Format: (Check Name, File Suffix, Architecture)
+# Format: (Check Name, File Suffix, Architecture, Number of Occurrences)
+# Common file suffixes:
+#   - `mo` -> For multi-output test cases
 @pytest.mark.parametrize(
     "check,suffix,arch,num_occurrences",
     [
+        ## license_file_overspecified ##
         # TODO add multi-output-test
         ("license_file_overspecified", "", "linux-64", 1),
         ("license_file_overspecified", "", "osx-arm64", 1),
         ("license_file_overspecified", "", "win-64", 1),
+        ## no_git_on_windows ##
         # TODO add multi-output-test
         ("no_git_on_windows", "", "win-64", 1),
-        # TODO add multi-output-test
+        ## version_constraints_missing_whitespace ##
         ("version_constraints_missing_whitespace", "", "linux-64", 4),
         ("version_constraints_missing_whitespace", "", "osx-arm64", 4),
         ("version_constraints_missing_whitespace", "", "win-64", 4),
+        ("version_constraints_missing_whitespace", "mo", "linux-64", 12),
+        ("version_constraints_missing_whitespace", "mo", "osx-arm64", 12),
+        ("version_constraints_missing_whitespace", "mo", "win-64", 12),
     ],
 )
 def test_auto_fix_rule(check: str, suffix: str, arch: str, num_occurrences: int):

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -16,19 +16,27 @@ from conftest import assert_on_auto_fix
 
 # Format: (Check Name, File Suffix, Architecture)
 @pytest.mark.parametrize(
-    "check,suffix,arch",
+    "check,suffix,arch,num_occurrences",
     [
-        ("license_file_overspecified", "", "linux-64"),
-        ("license_file_overspecified", "", "win-64"),
-        ("no_git_on_windows", "", "win-64"),
+        # TODO add multi-output-test
+        ("license_file_overspecified", "", "linux-64", 1),
+        ("license_file_overspecified", "", "osx-arm64", 1),
+        ("license_file_overspecified", "", "win-64", 1),
+        # TODO add multi-output-test
+        ("no_git_on_windows", "", "win-64", 1),
+        # TODO add multi-output-test
+        ("version_constraints_missing_whitespace", "", "linux-64", 2),
+        ("version_constraints_missing_whitespace", "", "osx-arm64", 2),
+        ("version_constraints_missing_whitespace", "", "win-64", 2),
     ],
 )
-def test_auto_fix_rule(check: str, suffix: str, arch: str):
+def test_auto_fix_rule(check: str, suffix: str, arch: str, num_occurrences: int):
     """
     Tests auto-fixable rules by passing in a file with the issue and checking the output with an expected file.
     Files must be stored in the `test_aux_files/auto_fix/` directory, following our naming conventions.
     :param check: Name of the linter check
     :param suffix: File suffix, allowing developers to create multiple test files against a linter check.
     :param arch: Architecture to run the test against.
+    :param num_occurrences: Number of times this rule should be triggered in the test file.
     """
-    assert_on_auto_fix(check, suffix, arch)
+    assert_on_auto_fix(check, suffix, arch, num_occurrences)

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -25,9 +25,9 @@ from conftest import assert_on_auto_fix
         # TODO add multi-output-test
         ("no_git_on_windows", "", "win-64", 1),
         # TODO add multi-output-test
-        ("version_constraints_missing_whitespace", "", "linux-64", 2),
-        ("version_constraints_missing_whitespace", "", "osx-arm64", 2),
-        ("version_constraints_missing_whitespace", "", "win-64", 2),
+        ("version_constraints_missing_whitespace", "", "linux-64", 4),
+        ("version_constraints_missing_whitespace", "", "osx-arm64", 4),
+        ("version_constraints_missing_whitespace", "", "win-64", 4),
     ],
 )
 def test_auto_fix_rule(check: str, suffix: str, arch: str, num_occurrences: int):

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -1,0 +1,34 @@
+"""
+File:           test_auto_fix_rules.py
+Description:    Tests the `fix()` function on linter rules, that allows us to "auto-fix" linter rules.
+
+                All of these tests are maintained in this file to significantly reduce test-code-duplication.
+
+                This feature can be easily tested with a utility function that looks for the names of two files:
+                  - An input test file that triggers the target linting rule
+                  - An output test file that matches an expected, automatically corrected, resulting file
+"""
+from __future__ import annotations
+
+import pytest
+from conftest import assert_on_auto_fix
+
+
+# Format: (Check Name, File Suffix, Architecture)
+@pytest.mark.parametrize(
+    "check,suffix,arch",
+    [
+        ("license_file_overspecified", "", "linux-64"),
+        ("license_file_overspecified", "", "win-64"),
+        ("no_git_on_windows", "", "win-64"),
+    ],
+)
+def test_auto_fix_rule(check: str, suffix: str, arch: str):
+    """
+    Tests auto-fixable rules by passing in a file with the issue and checking the output with an expected file.
+    Files must be stored in the `test_aux_files/auto_fix/` directory, following our naming conventions.
+    :param check: Name of the linter check
+    :param suffix: File suffix, allowing developers to create multiple test files against a linter check.
+    :param arch: Architecture to run the test against.
+    """
+    assert_on_auto_fix(check, suffix, arch)

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -2910,7 +2910,7 @@ def test_no_git_on_windows_auto_fix() -> None:
     """
     Tests the auto-fix functionality of the `no_git_on_windows` rule.
     """
-    assert_on_auto_fix("no_git_on_windows", "win-64")
+    assert_on_auto_fix("no_git_on_windows", arch="win-64")
 
 
 def test_gui_app_good(base_yaml: str) -> None:

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from conftest import assert_on_auto_fix, check, check_dir
+from conftest import check, check_dir
 
 from anaconda_linter.lint.check_build_help import BUILD_TOOLS, COMPILERS, PYTHON_BUILD_BACKENDS, PYTHON_BUILD_TOOLS
 
@@ -2904,13 +2904,6 @@ def test_no_git_on_windows_bad_multi(base_yaml: str) -> None:
     lint_check = "no_git_on_windows"
     messages = check(lint_check, yaml_str, arch="win-64")
     assert len(messages) == 2 and all("git should not be used" in msg.title for msg in messages)
-
-
-def test_no_git_on_windows_auto_fix() -> None:
-    """
-    Tests the auto-fix functionality of the `no_git_on_windows` rule.
-    """
-    assert_on_auto_fix("no_git_on_windows", arch="win-64")
 
 
 def test_gui_app_good(base_yaml: str) -> None:

--- a/tests/lint/test_completeness.py
+++ b/tests/lint/test_completeness.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from conftest import assert_on_auto_fix, check, check_dir
+from conftest import check, check_dir
 
 
 def test_missing_section_good(base_yaml: str) -> None:
@@ -236,13 +236,6 @@ def test_license_file_overspecified_bad(base_yaml: str) -> None:
     lint_check = "license_file_overspecified"
     messages = check(lint_check, yaml_str)
     assert len(messages) == 1 and "license_file and license_url is overspecified" in messages[0].title
-
-
-def test_license_file_overspecified_auto_fix() -> None:
-    """
-    Tests the auto-fix functionality of the `license_file_overspecified` rule.
-    """
-    assert_on_auto_fix("license_file_overspecified")
 
 
 def test_missing_license_family_good(base_yaml: str) -> None:

--- a/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace.yaml
+++ b/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace.yaml
@@ -1,0 +1,51 @@
+{% set name = "streamlit-folium" %}
+{% set version = "0.15.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/streamlit_folium-{{ version }}.tar.gz
+  sha256: 2908c98487e914493c730fb71c70fa6dfb1e482a404b7c10b7511579358701c1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<38 or s390x]
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+  run:
+    - python
+    - folium>=0.13
+    - streamlit>=1.13
+    - branca
+    - jinja2
+
+test:
+  imports:
+    - streamlit_folium
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/randyzwitch/streamlit-folium
+  summary: Render Folium objects in Streamlit
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  description: |
+    streamlit-folium integrates two great open-source projects in the Python ecosystem: Streamlit and Folium!
+  doc_url: https://github.com/randyzwitch/streamlit-folium/blob/master/README.md
+  dev_url: https://github.com/randyzwitch/streamlit-folium
+
+extra:
+  recipe-maintainers:
+    - randyzwitch

--- a/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace.yaml
+++ b/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace.yaml
@@ -16,16 +16,16 @@ build:
 
 requirements:
   host:
-    - pip
+    - pip <=1.4
     - python
     - setuptools
-    - wheel
+    - wheel==1.2.3
   run:
     - python
     - folium>=0.13
-    - streamlit>=1.13
+    - streamlit<=1.13  # [unix]
     - branca
-    - jinja2
+    - jinja2!=1.3.5.2
 
 test:
   imports:

--- a/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace_fixed.yaml
+++ b/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace_fixed.yaml
@@ -16,16 +16,16 @@ build:
 
 requirements:
   host:
-    - pip
+    - pip <=1.4
     - python
     - setuptools
-    - wheel
+    - wheel ==1.2.3
   run:
     - python
     - folium >=0.13
-    - streamlit >=1.13
+    - streamlit <=1.13  # [unix]
     - branca
-    - jinja2
+    - jinja2 !=1.3.5.2
 
 test:
   imports:

--- a/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace_fixed.yaml
+++ b/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace_fixed.yaml
@@ -1,0 +1,51 @@
+{% set name = "streamlit-folium" %}
+{% set version = "0.15.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/streamlit_folium-{{ version }}.tar.gz
+  sha256: 2908c98487e914493c730fb71c70fa6dfb1e482a404b7c10b7511579358701c1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<38 or s390x]
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - wheel
+  run:
+    - python
+    - folium >=0.13
+    - streamlit >=1.13
+    - branca
+    - jinja2
+
+test:
+  imports:
+    - streamlit_folium
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/randyzwitch/streamlit-folium
+  summary: Render Folium objects in Streamlit
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  description: |
+    streamlit-folium integrates two great open-source projects in the Python ecosystem: Streamlit and Folium!
+  doc_url: https://github.com/randyzwitch/streamlit-folium/blob/master/README.md
+  dev_url: https://github.com/randyzwitch/streamlit-folium
+
+extra:
+  recipe-maintainers:
+    - randyzwitch

--- a/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace_mo.yaml
+++ b/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace_mo.yaml
@@ -1,0 +1,88 @@
+{% set name = "streamlit-folium" %}
+{% set version = "0.15.0" %}
+
+outputs:
+  - name: foo1
+    requirements:
+      host:
+        - pip <=1.4
+        - python
+        - setuptools
+        - wheel==1.2.3
+      run:
+        - python
+        - folium>=0.13
+        - streamlit<=1.13  # [unix]
+        - branca
+        - jinja2!=1.3.5.2
+    test:
+      commands:
+        - test -m hello
+  - name: foo2
+    requirements:
+      host:
+        - pip <=1.4
+        - python
+        - setuptools
+        - wheel==1.2.3
+      run:
+        - python
+        - folium>=0.13
+        - streamlit<=1.13  # [unix]
+        - branca
+        - jinja2!=1.3.5.2
+    test:
+      commands:
+        - test -m hello
+  - name: foo3
+    requirements:
+      host:
+        - pip <=1.4
+        - python
+        - setuptools
+        - wheel==1.2.3
+      run:
+        - python
+        - folium>=0.13
+        - streamlit<=1.13  # [unix]
+        - branca
+        - jinja2!=1.3.5.2
+    test:
+      commands:
+        - test -m hello
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/streamlit_folium-{{ version }}.tar.gz
+  sha256: 2908c98487e914493c730fb71c70fa6dfb1e482a404b7c10b7511579358701c1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<38 or s390x]
+
+test:
+  imports:
+    - streamlit_folium
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/randyzwitch/streamlit-folium
+  summary: Render Folium objects in Streamlit
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  description: |
+    streamlit-folium integrates two great open-source projects in the Python ecosystem: Streamlit and Folium!
+  doc_url: https://github.com/randyzwitch/streamlit-folium/blob/master/README.md
+  dev_url: https://github.com/randyzwitch/streamlit-folium
+
+extra:
+  recipe-maintainers:
+    - randyzwitch

--- a/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace_mo_fixed.yaml
+++ b/tests/test_aux_files/auto_fix/version_constraints_missing_whitespace_mo_fixed.yaml
@@ -1,0 +1,88 @@
+{% set name = "streamlit-folium" %}
+{% set version = "0.15.0" %}
+
+outputs:
+  - name: foo1
+    requirements:
+      host:
+        - pip <=1.4
+        - python
+        - setuptools
+        - wheel ==1.2.3
+      run:
+        - python
+        - folium >=0.13
+        - streamlit <=1.13  # [unix]
+        - branca
+        - jinja2 !=1.3.5.2
+    test:
+      commands:
+        - test -m hello
+  - name: foo2
+    requirements:
+      host:
+        - pip <=1.4
+        - python
+        - setuptools
+        - wheel ==1.2.3
+      run:
+        - python
+        - folium >=0.13
+        - streamlit <=1.13  # [unix]
+        - branca
+        - jinja2 !=1.3.5.2
+    test:
+      commands:
+        - test -m hello
+  - name: foo3
+    requirements:
+      host:
+        - pip <=1.4
+        - python
+        - setuptools
+        - wheel ==1.2.3
+      run:
+        - python
+        - folium >=0.13
+        - streamlit <=1.13  # [unix]
+        - branca
+        - jinja2 !=1.3.5.2
+    test:
+      commands:
+        - test -m hello
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/streamlit_folium-{{ version }}.tar.gz
+  sha256: 2908c98487e914493c730fb71c70fa6dfb1e482a404b7c10b7511579358701c1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<38 or s390x]
+
+test:
+  imports:
+    - streamlit_folium
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/randyzwitch/streamlit-folium
+  summary: Render Folium objects in Streamlit
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  description: |
+    streamlit-folium integrates two great open-source projects in the Python ecosystem: Streamlit and Folium!
+  doc_url: https://github.com/randyzwitch/streamlit-folium/blob/master/README.md
+  dev_url: https://github.com/randyzwitch/streamlit-folium
+
+extra:
+  recipe-maintainers:
+    - randyzwitch


### PR DESCRIPTION
- Streamlines the auto-fix tests by using a test fixture setup for all auto fix tests
- Adds our first multi-output unit test to the auto fix roster
- Fixes a linting rule that was known to crash using some percy enhancements