### PR TITLE
First pass: Independent Execution

### DIFF
--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,6 +1,5 @@
 # This surpresses deprecation `pytest` warnings related to using `conda.*` packages.
-# TODO Future: remove/upgrade deprecated packages
 [pytest]
 filterwarnings =
-    ignore:conda.* is pending deprecation:PendingDeprecationWarning
-    ignore:conda.* is deprecated:DeprecationWarning
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -584,7 +584,7 @@ class Linter:
         verbose: bool = False,
         exclude: list[str] = None,
         nocatch: bool = False,
-        severity_min: Optional[Severity | str] = None,
+        severity_min: Optional[Severity] = None,
     ) -> None:
         """
         Constructs a linter instance
@@ -608,17 +608,7 @@ class Linter:
         self.nocatch = nocatch
         self.verbose = verbose
         self._messages: list[LintMessage] = []
-        # TODO rm: de-risk this. Enforce `Severity` over `str` universally
-        if isinstance(severity_min, Severity):
-            self.severity_min = severity_min
-        elif isinstance(severity_min, str):
-            try:
-                self.severity_min = Severity[severity_min]
-            except KeyError as e:
-                raise ValueError(f"Unrecognized severity level {severity_min}") from e
-        else:
-            self.severity_min = SEVERITY_MIN_DEFAULT
-
+        self.severity_min = SEVERITY_MIN_DEFAULT if severity_min is None else severity_min
         self.reload_checks()
 
     def reload_checks(self) -> None:
@@ -766,9 +756,8 @@ class Linter:
         result: Severity = Severity.NONE
         for message in self._messages:
             if message.severity == Severity.ERROR:
-                result = Severity.ERROR
-                break
-            elif message.severity == Severity.WARNING:
+                return Severity.ERROR
+            if message.severity == Severity.WARNING:
                 result = Severity.WARNING
 
         return result

--- a/anaconda_linter/utils.py
+++ b/anaconda_linter/utils.py
@@ -32,6 +32,11 @@ URLCache = dict[str, URLData]
 check_url_cache: URLCache = {}
 
 
+# TODO: Confirm this is correct
+# Represents a recipe's "config" or "cbc.yaml" file
+RecipeConfigType = dict[str, str | list[str]]
+
+
 def validate_config(path: str) -> None:
     """
     Validate config against schema
@@ -46,7 +51,8 @@ def validate_config(path: str) -> None:
             validate(config, schema)
 
 
-def load_config(path: str):
+# TODO determine type of "value"
+def load_config(path: str) -> RecipeConfigType:
     """
     Parses config file, building paths to relevant block-lists.
     TODO Future: determine if this config file is necessary and if we can just get away with constants in this file

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -151,35 +151,7 @@ def test_severity_level(base_yaml: str, level: Severity, string: str, lint_check
     assert messages[0].get_level() == string
 
 
-def test_severity_bad(base_yaml: str) -> None:  # pylint: disable=unused-argument
-    with pytest.raises(ValueError):
-        config_file = Path(__file__).parent / "config.yaml"
-        config = utils.load_config(config_file)
-        lint.Linter(config=config, severity_min="BADSEVERITY")
-
-
-# TODO rm: de-risk this. Enforce `Severity` over `str` universally
-@pytest.mark.parametrize("level,expected", (("INFO", 3), ("WARNING", 2), ("ERROR", 1)))
-def test_severity_min_string(base_yaml: str, level: str, expected: int) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        extra:
-          only-lint:
-            - DummyInfo
-            - DummyError
-            - DummyWarning
-        """
-    )
-    recipes = [Recipe.from_string(recipe_text=yaml_str, renderer=RendererType.RUAMEL)]
-    config_file = Path(__file__).parent / "config.yaml"
-    config = utils.load_config(config_file)
-    linter = lint.Linter(config=config, severity_min=level)
-    linter.lint(recipes)
-    assert len(linter.get_messages()) == expected
-
-
-@pytest.mark.parametrize("level,expected", ((Severity.INFO, 3), ("WARNING", 2), ("ERROR", 1)))
+@pytest.mark.parametrize("level,expected", ((Severity.INFO, 3), (Severity.WARNING, 2), (Severity.ERROR, 1)))
 def test_severity_min_enum(base_yaml: str, level: Severity | str, expected: int) -> None:
     yaml_str = (
         base_yaml


### PR DESCRIPTION
This is my first attempt at trying to allow us to call the linter's execution stack from another Python project.

I also finally removed the last of the Severity-strings. Now the CLI will sanitize input from the user. Everywhere else uses the Enum. The static analyzer will confirm this when we can get it up and running across this project.