### PR TITLE
Fixes PAT-270 bug

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 from percy.parser.recipe_parser import RecipeParser, SelectorConflictMode
 from percy.render.recipe import Recipe
@@ -944,8 +944,15 @@ class missing_python(LintCheck):
     """
 
     def check_recipe(self, recipe: Recipe) -> None:
+        ro_parser: Final[RecipeParser] = recipe.get_read_only_parser()
         is_pypi = is_pypi_source(recipe)
+        # TODO: Refactor and test this with the new parser work. PAT-273 tracks adding a comparable feature
+        #       to `recipe.packages` in the RecipeParser.
         for package in recipe.packages.values():
+            # PAT-270: Do not add `python` if the package is `noarch: generic`
+            if ro_parser.get_value(f"/{package.path_prefix}build/noarch", "") == "generic":
+                continue
+
             if (
                 is_pypi
                 or recipe.contains(f"{package.path_prefix}build/script", "pip install", "")
@@ -959,6 +966,7 @@ class missing_python(LintCheck):
                         )
 
     def fix(self, message, data) -> bool:
+        # TODO: Refactor and test this with the new parser work
         (recipe, package) = data
         op = [
             {

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -20,6 +20,7 @@ from conftest import assert_on_auto_fix
 @pytest.mark.parametrize(
     "check,suffix,arch,num_occurrences",
     [
+        ## avoid_noarch
         ## license_file_overspecified ##
         # TODO add multi-output-test
         ("license_file_overspecified", "", "linux-64", 1),

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -20,7 +20,6 @@ from conftest import assert_on_auto_fix
 @pytest.mark.parametrize(
     "check,suffix,arch,num_occurrences",
     [
-        ## avoid_noarch
         ## license_file_overspecified ##
         # TODO add multi-output-test
         ("license_file_overspecified", "", "linux-64", 1),

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -2559,6 +2559,73 @@ def test_missing_test_requirement_pip_script_bad_multi(base_yaml: str, recipe_di
     assert len(messages) == 2 and all("pip is required" in msg.title for msg in messages)
 
 
+def test_missing_python_does_not_trigger_on_noarch_generic(base_yaml: str) -> None:
+    """
+    Regression from PAT-270: Packages with `noarch: generic` should not fail this lint check.
+    """
+    yaml_str = (
+        base_yaml
+        + """
+        build:
+          noarch: generic
+        source:
+          url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+        requirements:
+          host:
+            - foo
+          run:
+            - bar
+        """
+    )
+    lint_check = "missing_python"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
+def test_missing_python_does_not_trigger_on_noarch_generic_multi_output(base_yaml: str) -> None:
+    """
+    Regression from PAT-270: Packages with `noarch: generic` should not fail this lint check. This checks for
+    multi-output recipes.
+    """
+    yaml_str = (
+        base_yaml
+        + """
+        outputs:
+          - name: test0
+            source:
+              url: https://github.com/foo/bar/bar-1.2.3.tar.gz
+            requirements:
+              host:
+                - foo
+              run:
+                - bar
+          - name: test1
+            build:
+              noarch: generic
+            source:
+              url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+            requirements:
+              host:
+                - foo
+              run:
+                - bar
+          - name: test2
+            build:
+              noarch: python
+            source:
+              url: https://pypi.io/packages/source/D/Django/Django-4.1.tar.gz
+            requirements:
+              host:
+                - python
+              run:
+                - python
+        """
+    )
+    lint_check = "missing_python"
+    messages = check(lint_check, yaml_str)
+    assert len(messages) == 0
+
+
 def test_missing_python_url_good(base_yaml: str) -> None:
     yaml_str = (
         base_yaml


### PR DESCRIPTION
- `noarch: generic` packages will no longer fail the `missing_python` check
- Adds regression tests