### PR TITLE
Addresses the bug found in PAT-249

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -843,7 +843,9 @@ class missing_pip_check(LintCheck):
                     for file in test_files:
                         self._check_file(os.path.join(recipe.dir, file), recipe, package)
                 else:
-                    self.message(section=f"{package.path_prefix}test")
+                    # In PAT-249, data was not being passed. Take this into consideration if/when this gets reworked to
+                    # use the recipe parser.
+                    self.message(section=f"{package.path_prefix}test", data=(recipe, package))
 
     def fix(self, message, data) -> bool:
         (recipe, package) = data
@@ -858,7 +860,7 @@ class missing_pip_check(LintCheck):
         return recipe.patch(op)
 
 
-class missing_test_requirement_pip(LintCheck):
+class missing_test_requirement_pip(LintCheck):  #
     """
     pip is required in the test requirements.
 


### PR DESCRIPTION
- Fixes bug described in the PAT-249 ticket
- This was casued by the fragility of the the message-passing system. Our static analyzer rules would have found this/prevented this, if we enabled them fully for this project.
- Normally I would add a regression test, but we have an epic to automate testing for all of our auto-fix rules and this rule will likely be refactored

Adding reviewers for visibility, but given the size and other work I have to do, I will probably just merge this when the automated checks pass.